### PR TITLE
@types/es6-promise should be a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
     "@types/es6-promise": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.33.tgz",
-      "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw=="
+      "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",
+    "@types/es6-promise": "0.0.33",
     "@types/fs-extra": "^4.0.1",
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.0.26",
@@ -44,7 +45,6 @@
     "typescript": "^2.5.2"
   },
   "dependencies": {
-    "@types/es6-promise": "0.0.33",
     "es6-promise": "^4.1.1",
     "fs-extra": "^4.0.1",
     "then-read-stream": "^1.0.3",


### PR DESCRIPTION
In our TypeScript project we have recently upgraded to the music-metadata module. In this project we use Bluebird for our promises, which unfortunately has definition conflicts with the es6-promise typings installed by this project.