### PR TITLE
Restructure to centralize types and…

### DIFF
--- a/src/AbstractTokenizer.ts
+++ b/src/AbstractTokenizer.ts
@@ -1,5 +1,5 @@
 import {IGetToken, IToken} from "token-types";
-import {endOfFile, ITokenizer} from "./";
+import {endOfFile, ITokenizer} from "./type";
 
 export abstract class AbstractTokenizer implements ITokenizer {
 

--- a/src/BufferTokenizer.ts
+++ b/src/BufferTokenizer.ts
@@ -1,5 +1,4 @@
-import {endOfFile} from "./";
-import {ITokenizer} from "./index";
+import {endOfFile, ITokenizer} from "./type";
 import {IGetToken, IToken} from "token-types";
 
 export class BufferTokenizer implements ITokenizer {

--- a/src/FileTokenizer.ts
+++ b/src/FileTokenizer.ts
@@ -1,5 +1,5 @@
 import {AbstractTokenizer} from "./AbstractTokenizer";
-import {endOfFile} from "./";
+import {endOfFile} from "./type";
 import {FsPromise} from "./FsPromise";
 
 export class FileTokenizer extends AbstractTokenizer {

--- a/src/ReadStreamTokenizer.ts
+++ b/src/ReadStreamTokenizer.ts
@@ -1,5 +1,5 @@
 import {AbstractTokenizer} from "./AbstractTokenizer";
-import {endOfFile} from "./";
+import {endOfFile} from "./type";
 import {endOfStream, StreamReader} from "then-read-stream";
 import * as Stream from "stream";
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,23 @@
+import {ReadStreamTokenizer} from "./ReadStreamTokenizer";
+import * as Stream from "stream";
+import {BufferTokenizer} from "./BufferTokenizer";
+
+/**
+ * Construct ReadStreamTokenizer from given Stream.
+ * Will set fileSize, if provided given Stream has set the .path property/
+ * @param stream Stream.Readable
+ * @param size If known the 'file' size in bytes, maybe required to calculate the duration.
+ * @returns ReadStreamTokenizer
+ */
+export function fromStream(stream: Stream.Readable, size?: number): ReadStreamTokenizer {
+  return new ReadStreamTokenizer(stream, size);
+}
+
+/**
+ * Construct ReadStreamTokenizer from given Buffer.
+ * @param buffer Buffer to tokenize
+ * @returns BufferTokenizer
+ */
+export function fromBuffer(buffer: Buffer): BufferTokenizer {
+  return new BufferTokenizer(buffer);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,78 +1,10 @@
-import {IGetToken} from 'token-types';
-import {ReadStreamTokenizer} from "./ReadStreamTokenizer";
-import {FileTokenizer} from "./FileTokenizer";
 import * as Stream from "stream";
-import {FsPromise} from "./FsPromise";
-import {BufferTokenizer} from "./BufferTokenizer";
 
-/**
- * Used to reject read if end-of-Stream or end-of-file is reached
- * @type {Error}
- */
-export const endOfFile = "End-Of-File";
-
-export interface ITokenizer {
-
-  /**
-   * File length in bytes
-   */
-  fileSize?: number;
-
-  /**
-   * Offset in bytes (= number of bytes read) since beginning of file or stream
-   */
-  position: number;
-
-  /**
-   * Peek (read ahead) buffer from tokenizer
-   * @param buffer
-   * @param offset is the offset in the buffer to start writing at; if not provided, start at 0
-   * @param length is an integer specifying the number of bytes to read
-   * @param position is an integer specifying where to begin reading from in the file. If position is null, data will be read from the current file position.
-   * @param maybeLess If true, will return the bytes available if available bytes is less then length.
-   * @returns {Promise<TResult|number>}
-   */
-  peekBuffer(buffer: Buffer, offset?: number, length?: number, position?: number, maybeLess?: boolean): Promise<number>;
-
-  /**
-   * Read buffer from tokenizer
-   * @param buffer
-   * @param offset is the offset in the buffer to start writing at; if not provided, start at 0
-   * @param length is an integer specifying the number of bytes to read
-   * @param position is an integer specifying where to begin reading from in the file. If position is null, data will be read from the current file position.
-   * @returns {Promise<TResult|number>}
-   */
-  readBuffer(buffer: Buffer, offset?: number, length?: number, position?: number): Promise<number>;
-
-  peekToken<T>(token: IGetToken<T>, position?: number | null): Promise<T>;
-
-  readToken<T>(token: IGetToken<T>, position?: number | null): Promise<T>;
-
-  peekNumber(token: IGetToken<number>): Promise<number>;
-
-  readNumber(token: IGetToken<number>): Promise<number>;
-
-  /**
-   * Ignore given number of bytes
-   * @param actual number of bytes ignored
-   */
-  ignore(length: number);
-}
-
-/**
- * Construct ReadStreamTokenizer from given Stream.
- * Will set fileSize, if provided given Stream has set the .path property/
- * @param stream Stream.Readable
- * @returns {Promise<ReadStreamTokenizer>}
- */
-export function fromStream(stream: Stream.Readable): Promise<ReadStreamTokenizer> {
-  if ((stream as any).path) {
-    return new FsPromise().stat((stream as any).path).then(stat => {
-      return new ReadStreamTokenizer(stream, stat.size);
-    }) as any;
-  }
-  return Promise.resolve(new ReadStreamTokenizer(stream));
-}
+import {FileTokenizer} from './FileTokenizer';
+import {FsPromise} from './FsPromise';
+import {ReadStreamTokenizer} from './ReadStreamTokenizer';
+import {BufferTokenizer} from './BufferTokenizer';
+import * as core from './core';
 
 /**
  * Construct ReadStreamTokenizer from given file path.
@@ -94,10 +26,23 @@ export function fromFile(filePath: string): Promise<FileTokenizer> {
 }
 
 /**
+ * Construct ReadStreamTokenizer from given Stream.
+ * Will set fileSize, if provided given Stream has set the .path property.
+ * @param stream Stream.Readable
+ * @returns {Promise<ReadStreamTokenizer>}
+ */
+export function fromStream(stream: Stream.Readable): Promise<ReadStreamTokenizer> {
+  if ((stream as any).path) {
+    return new FsPromise().stat((stream as any).path).then(stat => {
+      return core.fromStream(stream, stat.size);
+    });
+  }
+  return Promise.resolve(new ReadStreamTokenizer(stream));
+}
+
+/**
  * Construct ReadStreamTokenizer from given Buffer.
  * @param buffer Buffer to tokenize
  * @returns BufferTokenizer
  */
-export function fromBuffer(buffer: Buffer): BufferTokenizer {
-  return new BufferTokenizer(buffer);
-}
+export const fromBuffer = core.fromBuffer;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,55 @@
+import {IGetToken} from 'token-types';
+
+/**
+ * Used to reject read if end-of-Stream or end-of-file is reached
+ * @type {Error}
+ */
+export const endOfFile = "End-Of-File";
+
+export interface ITokenizer {
+
+  /**
+   * File length in bytes
+   */
+  fileSize?: number;
+
+  /**
+   * Offset in bytes (= number of bytes read) since beginning of file or stream
+   */
+  position: number;
+
+  /**
+   * Peek (read ahead) buffer from tokenizer
+   * @param buffer
+   * @param offset is the offset in the buffer to start writing at; if not provided, start at 0
+   * @param length is an integer specifying the number of bytes to read
+   * @param position is an integer specifying where to begin reading from in the file. If position is null, data will be read from the current file position.
+   * @param maybeLess If true, will return the bytes available if available bytes is less then length.
+   * @returns {Promise<TResult|number>}
+   */
+  peekBuffer(buffer: Buffer, offset?: number, length?: number, position?: number, maybeLess?: boolean): Promise<number>;
+
+  /**
+   * Read buffer from tokenizer
+   * @param buffer
+   * @param offset is the offset in the buffer to start writing at; if not provided, start at 0
+   * @param length is an integer specifying the number of bytes to read
+   * @param position is an integer specifying where to begin reading from in the file. If position is null, data will be read from the current file position.
+   * @returns {Promise<TResult|number>}
+   */
+  readBuffer(buffer: Buffer, offset?: number, length?: number, position?: number): Promise<number>;
+
+  peekToken<T>(token: IGetToken<T>, position?: number | null): Promise<T>;
+
+  readToken<T>(token: IGetToken<T>, position?: number | null): Promise<T>;
+
+  peekNumber(token: IGetToken<number>): Promise<number>;
+
+  readNumber(token: IGetToken<number>): Promise<number>;
+
+  /**
+   * Ignore given number of bytes
+   * @param actual number of bytes ignored
+   */
+  ignore(length: number);
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,9 +1,8 @@
 import * as Token from "token-types";
-import {} from "mocha";
 import {assert} from "chai";
-import * as strtok3 from "../src";
+import * as strtok3 from "../src/index";
 import * as Path from "path";
-import {ITokenizer} from "../src/index";
+import {endOfFile, ITokenizer} from "../src/type";
 import {FsPromise} from "../src/FsPromise";
 import {FileTokenizer} from "../src/FileTokenizer";
 
@@ -13,6 +12,10 @@ interface ITokenizerTest {
   name: string;
   loadTokenizer: (testFile: string) => Promise<ITokenizer>;
 }
+
+it("Promise", () => {
+  return Promise.resolve();
+});
 
 describe("Tokenizer-types", () => {
 
@@ -76,7 +79,7 @@ describe("Tokenizer-types", () => {
             return rst.readToken(Token.UINT8).then(() => {
               assert.fail("Should reject due to end-of-stream");
             }).catch(err => {
-              assert.equal(err.message, strtok3.endOfFile);
+              assert.equal(err.message, endOfFile);
             });
           });
         });
@@ -95,7 +98,7 @@ describe("Tokenizer-types", () => {
             return rst.readToken(Token.UINT8).then(() => {
               assert.fail("Should reject due to end-of-stream");
             }).catch(err => {
-              assert.equal(err.message, strtok3.endOfFile);
+              assert.equal(err.message, endOfFile);
             });
           });
 
@@ -507,7 +510,7 @@ describe("Tokenizer-types", () => {
 
       it("Handle peek token", () => {
 
-        function peekOnData(tokenizer: strtok3.ITokenizer): Promise<void> {
+        function peekOnData(tokenizer: ITokenizer): Promise<void> {
           assert.strictEqual(tokenizer.position, 0);
           return tokenizer.peekToken<number>(Token.UINT32_LE)
             .then(value => {
@@ -697,7 +700,7 @@ describe("Tokenizer-types", () => {
                 assert.equal(fileSize, bytesRead);
               }).then(() => {
                 return tokenizer.readBuffer(buf).catch(err => {
-                  assert.equal(err.message, strtok3.endOfFile);
+                  assert.equal(err.message, endOfFile);
                 });
               });
             });
@@ -719,7 +722,7 @@ describe("Tokenizer-types", () => {
             return rst.readToken(Token.INT32_BE).then(() => {
               assert.fail("It should throw EndOfFile Error");
             }).catch(err => {
-              assert.strictEqual(err.message, strtok3.endOfFile);
+              assert.strictEqual(err.message, endOfFile);
             });
           });
         });
@@ -732,7 +735,7 @@ describe("Tokenizer-types", () => {
             return rst.readBuffer(buffer).then(len => {
               assert.fail("It should throw EndOfFile Error");
             }).catch(err => {
-              assert.strictEqual(err.message, strtok3.endOfFile);
+              assert.strictEqual(err.message, endOfFile);
             });
           });
         });
@@ -745,7 +748,7 @@ describe("Tokenizer-types", () => {
             return rst.peekBuffer(buffer).then(len => {
               assert.fail("It should throw EndOfFile Error");
             }).catch(err => {
-              assert.strictEqual(err.message, strtok3.endOfFile);
+              assert.strictEqual(err.message, endOfFile);
             });
           });
         });


### PR DESCRIPTION
In addition to include the full module, allow only 'core' functionality using sub-module inclusion, e.,g:
```JavaScript
import * as strtok3 from 'strtok3/lib/core';
```

| function              | 'strtok3'           | 'strtok3/lib/core'  |
| ----------------------| --------------------|---------------------|
| `parseBuffer`         | :heavy_check_mark:  | :heavy_check_mark:  |
| `parseStream`         | :heavy_check_mark:  | :heavy_check_mark:  |
| `parseFromTokenizer`  | :heavy_check_mark:  | :heavy_check_mark:  |
| `fromFile`            | :heavy_check_mark:  |                     |

In the browser the following modules needs to be polyfilled:
1. stream
2. buffer

Relates issue: Borewit/music-metadata-browser#5