### PR TITLE
Fix reading 64-bit numbers

### DIFF
--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -16,7 +16,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    */
   public position: number = 0;
 
-  private numBuffer = Buffer.alloc(4);
+  private numBuffer = Buffer.alloc(8);
 
   /**
    * Read buffer from tokenizer


### PR DESCRIPTION
Fix issue #80: _readNumber(Token.UINT64_LE) throws error_