### PR TITLE
Increase rotating number buffer to 10 bytes to support 80-bit float

### DIFF
--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -16,7 +16,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    */
   public position: number = 0;
 
-  private numBuffer = Buffer.alloc(8);
+  private numBuffer = Buffer.alloc(10);
 
   /**
    * Read buffer from tokenizer


### PR DESCRIPTION
Related to [token-types#56](https://github.com/Borewit/token-types/pull/56)