### PR TITLE
Embed tokenizer interface in strtok3 (used to be token-types).

### DIFF
--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -1,5 +1,4 @@
-import { IGetToken, IToken } from 'token-types';
-import { endOfFile, ITokenizer } from './type';
+import { IGetToken, IToken, endOfFile, ITokenizer } from './types';
 
 /**
  * Core tokenizer

--- a/lib/BufferTokenizer.ts
+++ b/lib/BufferTokenizer.ts
@@ -1,5 +1,4 @@
-import { endOfFile, ITokenizer } from './type';
-import { IGetToken, IToken } from 'token-types';
+import { endOfFile, ITokenizer, IGetToken, IToken } from './types';
 
 export class BufferTokenizer implements ITokenizer {
 

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -1,5 +1,5 @@
 import { AbstractTokenizer } from './AbstractTokenizer';
-import { endOfFile } from './type';
+import { endOfFile } from './types';
 import * as fs from './FsPromise';
 
 export class FileTokenizer extends AbstractTokenizer {

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -1,5 +1,5 @@
 import { AbstractTokenizer } from './AbstractTokenizer';
-import { endOfFile } from './type';
+import { endOfFile } from './types';
 import { endOfStream, StreamReader } from 'then-read-stream';
 import * as Stream from 'stream';
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,10 +1,36 @@
-import {IGetToken} from 'token-types';
-
 /**
  * Used to reject read if end-of-Stream or end-of-file is reached
  * @type {Error}
  */
 export const endOfFile = "End-Of-File";
+
+export type IFlush = (b: Buffer, o: number) => void;
+
+export interface IGetToken<T> {
+
+  /**
+   * Length in bytes of encoded value
+   */
+  len: number;
+
+  /**
+   * Decode value from buffer at offset
+   * @param buf - Buffer to read the decoded value from
+   * @param off - Decode offset
+   */
+  get(buf: Buffer, off: number): T;
+}
+
+export interface IToken<T> extends IGetToken<T> {
+  /**
+   * Encode value to buffer
+   * @param buffer - Buffer to write the encoded value to
+   * @param offset - Buffer write offset
+   * @param value - Value to decode of type T
+   * @param flush ToDo
+   */
+  put(buffer: Buffer, offset: number, value: T, flush?: IFlush): number
+}
 
 export interface ITokenizer {
 

--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "remark-cli": "^7.0.1",
     "remark-preset-lint-recommended": "^3.0.3",
     "source-map-support": "^0.5.16",
+    "token-types": "^1.2.2",
     "ts-node": "^8.5.2",
     "tslint": "^5.20.1",
     "typescript": "^3.7.4"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "then-read-stream": "^2.0.8",
-    "token-types": "^1.2.2"
+    "then-read-stream": "^2.0.8"
   },
   "keywords": [
     "tokenizer",

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,7 +2,7 @@ import * as Token from 'token-types';
 import { assert } from 'chai';
 import * as strtok3 from '../lib';
 import * as Path from 'path';
-import { endOfFile, ITokenizer } from '../lib/type';
+import { endOfFile, ITokenizer } from '../lib/types';
 import * as fs from '../lib/FsPromise';
 import { FileTokenizer } from '../lib/FileTokenizer';
 


### PR DESCRIPTION
Issue #91

Embed tokenizer interface in [strtok3](https://github.com/Borewit/strtok3) (used to be defined in [token-types](https://github.com/Borewit/token-types)).