### PR TITLE
Extend strtok3 tokenizer with fileInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It can read from:
 npm install --save strtok3
 ```
 
-## Usage
+## API
 
 Use one of the methods to instantiate an [*abstract tokenizer*](#tokenizer):
 *   [strtok3.fromFile](#method-strtok3fromfile)
@@ -46,6 +46,8 @@ All of the strtok3 methods return a [*tokenizer*](#tokenizer), either directly o
 | Parameter | Type                  | Description                |
 |-----------|-----------------------|----------------------------|
 | path      | Path to file (string) | Path to file to read from  |
+
+Note that [file-information](#IFileInfo) is automatically added.
 
 Returns, via a promise, a [*tokenizer*](#tokenizer) which can be used to parse a file.
 
@@ -70,9 +72,10 @@ const Token = require('token-types');
 
 Create [*tokenizer*](#tokenizer) from a node.js [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
 
-| Parameter | Type                                                                        | Description                     |
-|-----------|-----------------------------------------------------------------------------|---------------------------------|
-| stream    | [Readable](https://nodejs.org/api/stream.html#stream_class_stream_readable) | Stream to read from             |
+| Parameter |  Optional | Type                                                                        | Description              |
+|-----------|-----------|-----------------------------------------------------------------------------|--------------------------|
+| stream    | no        | [Readable](https://nodejs.org/api/stream.html#stream_class_stream_readable) | Stream to read from      |
+| fileInfo  | yes       | [IFileInfo](#IFileInfo)                                                     | Provide file information |
 
 Returns a [*tokenizer*](#tokenizer), via a Promise, which can be used to parse a buffer.
 
@@ -89,9 +92,10 @@ strtok3.fromStream(stream).then(tokenizer => {
 
 #### Method `strtok3.fromBuffer()`
 
-| Parameter | Type                                         | Description         |
-|-----------|----------------------------------------------|---------------------|
-| buffer    | [Buffer](https://nodejs.org/api/buffer.html) | Buffer to read from |
+| Parameter | Optional | Type                                         | Description              |
+|-----------|----------|----------------------------------------------|--------------------------|
+| buffer    | no       | [Buffer](https://nodejs.org/api/buffer.html) | Buffer to read from      |
+| fileInfo  | yes      | [IFileInfo](#IFileInfo)                      | Provide file information |
 
 Returns a [*tokenizer*](#tokenizer) which can be used to parse the provided buffer.
 
@@ -115,10 +119,10 @@ What is the difference with Nodejs.js stream?
 
 The [tokenizer.position](#attribute-tokenizerposition) keeps tracks of
 
-### Tokenizer attributes
+### strtok3 attributes
 
-#### Attribute `tokenizer.fileSize`
-Optional attribute of the total file or stream length in bytes
+#### Attribute `tokenizer.fileInfo`
+Optional attribute describing the file information, see [IFileInfo](#IFileInfo)
 
 #### Attribute `tokenizer.position`
 Pointer to the current position in the [*tokenizer*](#tokenizer) stream.
@@ -211,6 +215,33 @@ Return value `Promise<number>` Promise with number peeked from the *tokenizer-st
 
 #### Method `tokenizer.close()`
 Clean up resources, such as closing a file pointer if applicable.
+
+## IFileInfo
+
+File information interface which describes the underlying file:
+
+```ts
+export interface IFileInfo {
+  /**
+   * File size in bytes
+   */
+  size?: number;
+  /**
+   * MIME-type of file
+   */
+  mimeType?: string;
+
+  /**
+   * File path
+   */
+  path?: string;
+
+  /**
+   * File URL
+   */
+  url?: string;
+}
+```
 
 ## Token
 

--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from './types';
+import { ITokenizer, IFileInfo } from './types';
 import { EndOfStreamError } from 'then-read-stream';
 import { IGetToken, IToken } from '@tokenizer/token';
 
@@ -7,10 +7,11 @@ import { IGetToken, IToken } from '@tokenizer/token';
  */
 export abstract class AbstractTokenizer implements ITokenizer {
 
-  /**
-   * Total file or stream length in bytes
-   */
-  public fileSize?: number;
+  public fileInfo: IFileInfo;
+
+  protected constructor(fileInfo?: IFileInfo) {
+    this.fileInfo = fileInfo ? fileInfo : {};
+  }
 
   /**
    * Tokenizer-stream position

--- a/lib/BufferTokenizer.ts
+++ b/lib/BufferTokenizer.ts
@@ -1,15 +1,20 @@
-import { ITokenizer } from './types';
+import { IFileInfo, ITokenizer } from './types';
 import { EndOfStreamError } from 'then-read-stream';
 import { IGetToken, IToken } from '@tokenizer/token';
 
 export class BufferTokenizer implements ITokenizer {
 
+  public fileInfo: IFileInfo;
   public position: number = 0;
 
-  public fileSize: number;
-
-  constructor(private buffer: Buffer) {
-    this.fileSize = buffer.length;
+  /**
+   * Construct BufferTokenizer
+   * @param buffer - Buffer to tokenize
+   * @param fileInfo - Pass additional file information to the tokenizer
+   */
+  constructor(private buffer: Buffer, fileInfo?: IFileInfo) {
+    this.fileInfo = fileInfo ? fileInfo : {};
+    this.fileInfo.size = this.fileInfo.size ?  this.fileInfo.size : buffer.length;
   }
 
   /**

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -1,11 +1,12 @@
 import { AbstractTokenizer } from './AbstractTokenizer';
 import { EndOfStreamError } from 'then-read-stream';
 import * as fs from './FsPromise';
+import { IFileInfo } from './types';
 
 export class FileTokenizer extends AbstractTokenizer {
 
-  public constructor(private fd: number, public sourceFilePath: string, public fileSize?: number) {
-    super();
+  public constructor(private fd: number, fileInfo: IFileInfo) {
+    super(fileInfo);
   }
 
   /**
@@ -59,11 +60,11 @@ export class FileTokenizer extends AbstractTokenizer {
   }
 
   /**
-   * @param length Number of bytes to ignore
+   * @param length - Number of bytes to ignore
    * @return resolves the number of bytes ignored, equals length if this available, otherwise the number of bytes available
    */
   public async ignore(length: number): Promise<number> {
-    const bytesLeft = this.fileSize - this.position;
+    const bytesLeft = this.fileInfo.size - this.position;
     if (length <= bytesLeft) {
       this.position += length;
       return length;
@@ -84,5 +85,5 @@ export async function fromFile(sourceFilePath: string): Promise<FileTokenizer> {
     throw new Error(`File not a file: ${sourceFilePath}`);
   }
   const fd = await fs.open(sourceFilePath, 'r');
-  return new FileTokenizer(fd, sourceFilePath, stat.size);
+  return new FileTokenizer(fd, {path: sourceFilePath, size: stat.size});
 }

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -1,21 +1,27 @@
 import { AbstractTokenizer } from './AbstractTokenizer';
 import { EndOfStreamError, StreamReader } from 'then-read-stream';
 import * as Stream from 'stream';
-
+import { IFileInfo } from './types';
 import * as _debug from 'debug';
 
 const debug = _debug('strtok3:ReadStreamTokenizer');
-
 const maxBufferSize = 1 * 1000 * 1000;
 
 export class ReadStreamTokenizer extends AbstractTokenizer {
 
   private streamReader: StreamReader;
 
-  public constructor(stream: Stream.Readable, fileSize?: number) {
-    super();
+  public constructor(stream: Stream.Readable, fileInfo?: IFileInfo) {
+    super(fileInfo);
     this.streamReader = new StreamReader(stream);
-    this.fileSize = fileSize;
+  }
+
+  /**
+   * Get file information, an HTTP-client may implement this doing a HEAD request
+   * @return Promise with file information
+   */
+  public async getFileInfo(): Promise<IFileInfo> {
+    return this.fileInfo;
   }
 
   /**

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,26 +1,29 @@
 import { ReadStreamTokenizer } from './ReadStreamTokenizer';
 import * as Stream from 'stream';
 import { BufferTokenizer } from './BufferTokenizer';
+import { IFileInfo } from './types';
 export { EndOfStreamError } from 'then-read-stream';
-export {  ITokenizer } from './types';
+export {  ITokenizer, IFileInfo } from './types';
 export { IToken, IGetToken } from '@tokenizer/token';
 
 /**
  * Construct ReadStreamTokenizer from given Stream.
  * Will set fileSize, if provided given Stream has set the .path property/
  * @param stream - Read from Node.js Stream.Readable
- * @param size - If known the 'file' size in bytes, maybe required to calculate the duration.
+ * @param fileInfo - Pass the file information, like size and MIME-type of the correspnding stream.
  * @returns ReadStreamTokenizer
  */
-export function fromStream(stream: Stream.Readable, size?: number): ReadStreamTokenizer {
-  return new ReadStreamTokenizer(stream, size);
+export function fromStream(stream: Stream.Readable, fileInfo?: IFileInfo): ReadStreamTokenizer {
+  fileInfo = fileInfo ? fileInfo : {};
+  return new ReadStreamTokenizer(stream, fileInfo);
 }
 
 /**
  * Construct ReadStreamTokenizer from given Buffer.
  * @param buffer - Buffer to tokenize
+ * @param fileInfo - Pass additional file information to the tokenizer
  * @returns BufferTokenizer
  */
-export function fromBuffer(buffer: Buffer): BufferTokenizer {
-  return new BufferTokenizer(buffer);
+export function fromBuffer(buffer: Buffer, fileInfo?: IFileInfo): BufferTokenizer {
+  return new BufferTokenizer(buffer, fileInfo);
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,19 +5,22 @@ import { ReadStreamTokenizer } from './ReadStreamTokenizer';
 import * as core from './core';
 
 export { fromFile } from './FileTokenizer';
-export { ITokenizer, EndOfStreamError, fromBuffer } from './core';
+export { ITokenizer, EndOfStreamError, fromBuffer, IFileInfo } from './core';
 export { IToken, IGetToken } from '@tokenizer/token';
 
 /**
  * Construct ReadStreamTokenizer from given Stream.
  * Will set fileSize, if provided given Stream has set the .path property.
  * @param stream - Node.js Stream.Readable
+ * @param fileInfo - Pass additional file information to the tokenizer
  * @returns Tokenizer
  */
-export async function fromStream(stream: Stream.Readable): Promise<ReadStreamTokenizer> {
+export async function fromStream(stream: Stream.Readable, fileInfo?: core.IFileInfo): Promise<ReadStreamTokenizer> {
+  fileInfo = fileInfo ? fileInfo : {};
   if ((stream as any).path) {
     const stat = await fs.stat((stream as any).path);
-    return core.fromStream(stream, stat.size);
+    fileInfo.path = (stream as any).path;
+    fileInfo.size = stat.size;
   }
-  return new ReadStreamTokenizer(stream);
+  return core.fromStream(stream, fileInfo);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,16 +1,36 @@
+import { IGetToken } from '@tokenizer/token';
+
+export interface IFileInfo {
+  /**
+   * File size in bytes
+   */
+  size?: number;
+  /**
+   * MIME-type of file
+   */
+  mimeType?: string;
+
+  /**
+   * File path
+   */
+  path?: string;
+
+  /**
+   * File URL
+   */
+  url?: string;
+}
+
 /**
  * The tokenizer allows us to read or peek from the tokenizer-stream.
  * The tokenizer-stream is an abstraction of a stream, file or Buffer.
- * It can also be translated in chunked reads, as done in @tokenizer/http;
  */
-import { IGetToken } from '@tokenizer/token';
-
 export interface ITokenizer {
 
   /**
-   * File length in bytes
+   * Provide access to information of the underlying information stream or file.
    */
-  fileSize?: number;
+  fileInfo: IFileInfo;
 
   /**
    * Offset in bytes (= number of bytes read) since beginning of file or stream

--- a/test/test.ts
+++ b/test/test.ts
@@ -11,7 +11,7 @@ interface ITokenizerTest {
   loadTokenizer: (testFile: string) => Promise<strtok3.ITokenizer>;
 }
 
-describe('Tokenizer-types', () => {
+describe('strtok3', () => {
 
   function getResourcePath(testFile: string) {
     return Path.join(__dirname, 'resources', testFile);
@@ -108,7 +108,7 @@ describe('Tokenizer-types', () => {
 
         // ToDo
         const rst = await tokenizerType.loadTokenizer('test1.dat');
-        assert.equal(rst.fileSize, 16, ' ReadStreamTokenizer.fileSize');
+        assert.equal(rst.fileInfo.size, 16, ' ReadStreamTokenizer.fileSize.size');
 
         await rst.close();
       });
@@ -499,7 +499,7 @@ describe('Tokenizer-types', () => {
         const rst = await tokenizerType.loadTokenizer('test1.dat');
 
         if (rst instanceof FileTokenizer) {
-          assert.equal(rst.fileSize, 16, 'check file size property');
+          assert.equal(rst.fileInfo.size, 16, 'check file size property');
         }
         await peekOnData(rst);
         await rst.close();
@@ -579,14 +579,14 @@ describe('Tokenizer-types', () => {
 
       it('number', async () => {
         const tokenizer = await tokenizerType.loadTokenizer('test3.dat');
-        await tokenizer.ignore(tokenizer.fileSize - 4);
+        await tokenizer.ignore(tokenizer.fileInfo.size - 4);
         const x = await tokenizer.peekNumber(Token.INT32_BE);
         assert.strictEqual(x, 33752069);
       });
 
       it('should throw an Error if we reach EOF while peeking a number', async () => {
         const tokenizer = await tokenizerType.loadTokenizer('test3.dat');
-        await tokenizer.ignore(tokenizer.fileSize - 3);
+        await tokenizer.ignore(tokenizer.fileInfo.size - 3);
         try {
           const x = await tokenizer.peekNumber(Token.INT32_BE);
           assert.fail('Should throw Error: End-Of-File');
@@ -711,7 +711,7 @@ describe('Tokenizer-types', () => {
       it('should be able to read from a file', async () => {
 
         const tokenizer = await tokenizerType.loadTokenizer('test1.dat');
-        assert.equal(tokenizer.fileSize, 16, 'check file size property');
+        assert.equal(tokenizer.fileInfo.size, 16, 'check file size property');
         let value = await tokenizer.readToken(Token.UINT32_LE);
         assert.equal(typeof value, 'number');
         assert.equal(value, 0x001a001a, 'UINT24_LE #1');


### PR DESCRIPTION
Implementation of #101

* [x] Implement `tokenizer.fileInfo`
* [x] Update API documentation (README)