### PR TITLE
Remove dependency debug

### DIFF
--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -2,9 +2,9 @@ import { AbstractTokenizer } from './AbstractTokenizer';
 import { EndOfStreamError, StreamReader } from 'peek-readable';
 import * as Stream from 'stream';
 import { IFileInfo, IReadChunkOptions } from './types';
-import * as _debug from 'debug';
+// import * as _debug from 'debug';
 
-const debug = _debug('strtok3:ReadStreamTokenizer');
+// const debug = _debug('strtok3:ReadStreamTokenizer');
 const maxBufferSize = 256000;
 
 export class ReadStreamTokenizer extends AbstractTokenizer {
@@ -126,7 +126,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
   }
 
   public async ignore(length: number): Promise<number> {
-    debug(`ignore ${this.position}...${this.position + length - 1}`);
+    // debug(`ignore ${this.position}...${this.position + length - 1}`);
     const bufSize = Math.min(maxBufferSize, length);
     const buf = Buffer.alloc(bufSize);
     let totBytesRead = 0;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@tokenizer/token": "^0.1.1",
     "@types/debug": "^4.1.5",
-    "debug": "^4.1.1",
     "peek-readable": "^3.1.0"
   },
   "keywords": [


### PR DESCRIPTION
Remove dependency on [debug](https://github.com/visionmedia/debug) as it is hardly used.

Resolves #305.