### PR TITLE
Update dependency to token-types v3.0.0 using BigInt

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "npm run compile && npm run lint && npm run cover-test"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",
@@ -60,7 +60,7 @@
     "remark-cli": "^9.0.0",
     "remark-preset-lint-recommended": "^5.0.0",
     "source-map-support": "^0.5.16",
-    "token-types": "^2.1.1",
+    "token-types": "^3.0.0",
     "ts-node": "^10.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,10 +3566,10 @@ to-vfile@^6.0.0:
     is-buffer "^2.0.0"
     vfile "^4.0.0"
 
-token-types@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.1.1.tgz#bd585d64902aaf720b8979d257b4b850b4d45c45"
-  integrity sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==
+token-types@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-3.0.0.tgz#982fb4e705103bc647fd281b06de213ea06ce65a"
+  integrity sha512-1cV7R6TRKfCG1++se5xGy9fUpD+L1u/7XgmViGA1Y5bubHt6W4w1r1j0uOk+5ngM6yhssRJ+qR+IaviVgAizJA==
   dependencies:
     "@tokenizer/token" "^0.1.1"
     ieee754 "^1.2.1"


### PR DESCRIPTION
Update Node.js engine to version 10.

Related: Borewit/token-types#300