### PR TITLE
Downgrade @tokenizer/token to version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@tokenizer/token": "^0.2.0",
+    "@tokenizer/token": "^0.1.1",
     "@types/debug": "^4.1.6",
     "peek-readable": "^3.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,11 +158,6 @@
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
   integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
 
-"@tokenizer/token@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.2.0.tgz#7bb0b297cbc9a3476c6556516336a81b86eb04d1"
-  integrity sha512-fflBWuCBMLlP1cdB0oltjTGxBLwMCX8Z4P7mcK+IA/v4+tBH/ECe1YRcZJHgoiupzTx9HT4cFmqQycNq4ZivaQ==
-
 "@tsconfig/node10@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.7.tgz#1eb1de36c73478a2479cc661ef5af1c16d86d606"


### PR DESCRIPTION
Version 0.2.0 is using Uint8Array instead of Buffer.
This gives problems in dependencies.

Fixes: #512