### PR TITLE
Update dependency strtok3 v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `strtok3` contains a few methods to turn different input into a [*tokenizer*
 It can read from:
 *   A file (taking a file path as an input)
 *   A Node.js [stream](https://nodejs.org/api/stream.html).
-*   A [Buffer](https://nodejs.org/api/buffer.html)
+*   A [Buffer](https://nodejs.org/api/buffer.html) or [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 *   HTTP chunked transfer provided by [@tokenizer/http](https://github.com/Borewit/tokenizer-http).
 *   Chunked [Amazon S3](https://aws.amazon.com/s3) access provided by [@tokenizer/s3](https://github.com/Borewit/tokenizer-s3).
 
@@ -35,7 +35,8 @@ npm install strtok3
 Use one of the methods to instantiate an [*abstract tokenizer*](#tokenizer):
 *   [strtok3.fromFile](#method-strtok3fromfile)
 *   [strtok3.fromStream](#method-strtok3fromstream)
-*   [strtok3.fromBuffer](#method-strtok3frombuffer)
+*   [strtok3.fromBuffer](#method-strtok3fromBuffer)
+*   [strtok3.fromUint8Array](#method-strtok3fromUint8Array)
 
 ### strtok3 methods
 
@@ -92,10 +93,10 @@ strtok3.fromStream(stream).then(tokenizer => {
 
 #### Method `strtok3.fromBuffer()`
 
-| Parameter | Optional | Type                                         | Description              |
-|-----------|----------|----------------------------------------------|--------------------------|
-| buffer    | no       | [Buffer](https://nodejs.org/api/buffer.html) | Buffer to read from      |
-| fileInfo  | yes      | [IFileInfo](#IFileInfo)                      | Provide file information |
+| Parameter  | Optional | Type                                             | Description                            |
+|------------|----------|--------------------------------------------------|----------------------------------------|
+| uint8Array | no       | [Uint8Array](https://nodejs.org/api/buffer.html) | Uint8Array or Buffer to read from      |
+| fileInfo   | yes      | [IFileInfo](#IFileInfo)                          | Provide file information               |
 
 Returns a [*tokenizer*](#tokenizer) which can be used to parse the provided buffer.
 

--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -18,7 +18,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    */
   public position: number = 0;
 
-  private numBuffer = Buffer.alloc(10);
+  private numBuffer = new Uint8Array(8);
 
   /**
    * Read buffer from tokenizer
@@ -26,7 +26,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @param options - Additional read options
    * @returns Promise with number of bytes read
    */
-  public abstract readBuffer(buffer: Buffer | Uint8Array, options?: IReadChunkOptions): Promise<number>;
+  public abstract readBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number>;
 
   /**
    * Peek (read ahead) buffer from tokenizer
@@ -34,7 +34,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @param options - Peek behaviour options
    * @returns Promise with number of bytes read
    */
-  public abstract peekBuffer(buffer: Buffer | Uint8Array, options?: IReadChunkOptions): Promise<number>;
+  public abstract peekBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number>;
 
   /**
    * Read a token from the tokenizer-stream
@@ -42,12 +42,12 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @param position - If provided, the desired position in the tokenizer-stream
    * @returns Promise with token data
    */
-  public async readToken<T>(token: IGetToken<T>, position?: number): Promise<T> {
-    const buffer = Buffer.alloc(token.len);
-    const len = await this.readBuffer(buffer, {position});
+  public async readToken<Value>(token: IGetToken<Value>, position?: number): Promise<Value> {
+    const uint8Array = Buffer.alloc(token.len);
+    const len = await this.readBuffer(uint8Array, {position});
     if (len < token.len)
       throw new EndOfStreamError();
-    return token.get(buffer, 0);
+    return token.get(uint8Array, 0);
   }
 
   /**
@@ -56,12 +56,12 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @param position - Offset where to begin reading within the file. If position is null, data will be read from the current file position.
    * @returns Promise with token data
    */
-  public async peekToken<T>(token: IGetToken<T>, position: number = this.position): Promise<T> {
-    const buffer = Buffer.alloc(token.len);
-    const len = await this.peekBuffer(buffer, {position});
+  public async peekToken<Value>(token: IGetToken<Value>, position: number = this.position): Promise<Value> {
+    const uint8Array = Buffer.alloc(token.len);
+    const len = await this.peekBuffer(uint8Array, {position});
     if (len < token.len)
       throw new EndOfStreamError();
-    return token.get(buffer, 0);
+    return token.get(uint8Array, 0);
   }
 
   /**

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -54,7 +54,7 @@ export class FileTokenizer extends AbstractTokenizer {
    * @param options - Read behaviour options
    * @returns Promise number of bytes read
    */
-  public async peekBuffer(buffer: Buffer, options?: IReadChunkOptions): Promise<number> {
+  public async peekBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number> {
 
     let offset = 0;
     let length = buffer.length;

--- a/lib/FsPromise.ts
+++ b/lib/FsPromise.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 
 export interface IReadResult {
   bytesRead: number,
-  buffer: Buffer
+  buffer: Uint8Array
 }
 
 export const pathExists = fs.existsSync;
@@ -45,7 +45,7 @@ export async function open(path: fs.PathLike, mode?: string): Promise<number> {
   });
 }
 
-export async function read(fd: number, buffer: Buffer, offset: number, length: number, position: number): Promise<IReadResult> {
+export async function read(fd: number, buffer: Uint8Array, offset: number, length: number, position: number): Promise<IReadResult> {
   return new Promise<IReadResult>((resolve, reject) => {
     fs.read(fd, buffer, offset, length, position, (err, bytesRead, _buffer) => {
       if (err)

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -2,9 +2,7 @@ import { AbstractTokenizer } from './AbstractTokenizer';
 import { EndOfStreamError, StreamReader } from 'peek-readable';
 import * as Stream from 'stream';
 import { IFileInfo, IReadChunkOptions } from './types';
-// import * as _debug from 'debug';
 
-// const debug = _debug('strtok3:ReadStreamTokenizer');
 const maxBufferSize = 256000;
 
 export class ReadStreamTokenizer extends AbstractTokenizer {
@@ -30,7 +28,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
    * @param options - Read behaviour options
    * @returns Promise with number of bytes read
    */
-  public async readBuffer(buffer: Buffer | Uint8Array, options?: IReadChunkOptions): Promise<number> {
+  public async readBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number> {
 
     // const _offset = position ? position : this.position;
     // debug(`readBuffer ${_offset}...${_offset + length - 1}`);
@@ -78,7 +76,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
    * @param options - Read behaviour options
    * @returns Promise with number of bytes peeked
    */
-  public async peekBuffer(buffer: Buffer | Uint8Array, options?: IReadChunkOptions): Promise<number> {
+  public async peekBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number> {
 
     // const _offset = position ? position : this.position;
     // debug(`peek ${_offset}...${_offset + length - 1}`);
@@ -101,9 +99,9 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
       if (options.position) {
         const skipBytes = options.position - this.position;
         if (skipBytes > 0) {
-          const skipBuffer = Buffer.alloc(length + skipBytes);
+          const skipBuffer = new Uint8Array(length + skipBytes);
           bytesRead = await this.peekBuffer(skipBuffer, {mayBeLess: options.mayBeLess});
-          skipBuffer.copy(buffer, offset, skipBytes);
+          buffer.set(skipBuffer.subarray(skipBytes), offset);
           return bytesRead - skipBytes;
         } else if (skipBytes < 0) {
           throw new Error('Cannot peek from a negative offset in a stream');
@@ -128,7 +126,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
   public async ignore(length: number): Promise<number> {
     // debug(`ignore ${this.position}...${this.position + length - 1}`);
     const bufSize = Math.min(maxBufferSize, length);
-    const buf = Buffer.alloc(bufSize);
+    const buf = new Uint8Array(bufSize);
     let totBytesRead = 0;
     while (totBytesRead < length) {
       const remaining = length - totBytesRead;

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -20,10 +20,10 @@ export function fromStream(stream: Stream.Readable, fileInfo?: IFileInfo): ReadS
 
 /**
  * Construct ReadStreamTokenizer from given Buffer.
- * @param buffer - Buffer to tokenize
+ * @param uint8Array - Uint8Array to tokenize
  * @param fileInfo - Pass additional file information to the tokenizer
  * @returns BufferTokenizer
  */
-export function fromBuffer(buffer: Buffer, fileInfo?: IFileInfo): BufferTokenizer {
-  return new BufferTokenizer(buffer, fileInfo);
+export function fromBuffer(uint8Array: Uint8Array, fileInfo?: IFileInfo): BufferTokenizer {
+  return new BufferTokenizer(uint8Array, fileInfo);
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "url": "https://github.com/Borewit/strtok3/issues"
   },
   "devDependencies": {
+    "@tokenizer/token": "^0.3.0",
     "@types/chai": "^4.2.21",
     "@types/debug": "^4.1.6",
     "@types/mocha": "^8.2.3",
@@ -67,8 +68,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@tokenizer/token": "^0.1.1",
-    "peek-readable": "^3.1.4"
+    "peek-readable": "^4.0.0"
   },
   "keywords": [
     "tokenizer",

--- a/test/test.ts
+++ b/test/test.ts
@@ -18,7 +18,7 @@ function getResourcePath(testFile: string) {
 
 async function getTokenizerWithData(testData: string, test: ITokenizerTest): Promise<strtok3.ITokenizer> {
   const testPath = getResourcePath('tmp.dat');
-  await fs.writeFile(testPath, Buffer.from(testData, 'binary'));
+  await fs.writeFile(testPath, Buffer.from(testData, 'latin1'));
   return test.loadTokenizer('tmp.dat');
 }
 
@@ -642,7 +642,7 @@ for (const tokenizerType of tokenizerTests) {
       const rst = await getTokenizerWithData('\x05peter', tokenizerType);
       // should decode string from chunk
       assert.strictEqual(rst.position, 0);
-      const value = await rst.peekToken(new Token.StringType(5, 'utf-8'), 1);
+      const value = await rst.peekToken(new Token.StringType(5, 'latin1'), 1);
       assert.equal(typeof value, 'string');
       assert.equal(value, 'peter');
       assert.strictEqual(rst.position, 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,11 @@
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
   integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
 
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.7.tgz#1eb1de36c73478a2479cc661ef5af1c16d86d606"
@@ -2717,10 +2722,10 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-peek-readable@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.4.tgz#f5c3b41a4eeb63a1322c4131f0b5bac7105b892e"
-  integrity sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg==
+peek-readable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.0.tgz#b024ef391c86136eba0ae9df3ff4f966a09e9a7e"
+  integrity sha512-kLbU4cz6h86poGVBKgAVMpFmD47nX04fPPQNKnv9fuj+IJZYkEBjsYAVu5nDbZWx0ZsWwWlMzeG90zQa5KLBaA==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Update dependency @tokenizer/token v0.3.0 for better Uint8Array abstraction

Update dependencies: 
1 [@tokenizer/token v0.3.0](https://github.com/Borewit/tokenizer-token/releases/tag/v0.3.0)
2. [peek-readable v4.0.0](https://github.com/Borewit/peek-readable/releases/tag/v4.0.0)

Related to: 
1. Borewit/token-types#246, Borewit/tokenizer-token#4

Depends on: 
1. Borewit/peek-readable#330
2. Borewit/token-types#246 (unit test dependency)