### PR TITLE
Change `@tokenizer/token` into a normal dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ It can read from:
 npm install strtok3
 ```
 
-Using TypeScript you should also install [@tokenizer/token](https://github.com/Borewit/tokenizer-token) as a development
-dependency:
-
-```shell
-npm install --save-dev @tokenizer/token
-```
-
 ## API
 
 Use one of the methods to instantiate an [*abstract tokenizer*](#tokenizer):

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "url": "https://github.com/Borewit/strtok3/issues"
   },
   "devDependencies": {
-    "@tokenizer/token": "^0.3.0",
     "@types/chai": "^4.2.21",
     "@types/debug": "^4.1.6",
     "@types/mocha": "^8.2.3",
@@ -68,6 +67,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@tokenizer/token": "^0.3.0",
     "peek-readable": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Fix: Borewit/music-metadata#866