### PR TITLE
Attempt to import a polyfill stream in case of `default`

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,5 +1,5 @@
 import { ReadStreamTokenizer } from './ReadStreamTokenizer.js';
-import Stream from 'node:stream';
+import Stream from '#stream';
 import { BufferTokenizer } from './BufferTokenizer.js';
 import { IFileInfo } from './types.js';
 export { EndOfStreamError } from 'peek-readable';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
     },
     "./core": "./lib/core.js"
   },
+  "imports": {
+    "#stream": {
+      "default": "readable-stream",
+      "node": "node:stream"
+    }
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib/**/*.js",


### PR DESCRIPTION
Import `node:stream` if Node.js, otherwise `readable-stream`.

Related documentation: https://nodejs.org/api/packages.html#packages_subpath_imports