### PR TITLE
Enable strict mode in TypeScript compiler

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,13 +54,32 @@
       "error",
       "always"
     ],
-    /*
-    "@typescript-eslint/space-within-parens": [
-      "error",
-      "always"
-    ],*/
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/unified-signatures": "error",
+    "@typescript-eslint/tslint/config": [
+      "error",
+      {
+        "rules": {
+          "jsdoc-format": [
+            true,
+            "check-multiline-start"
+          ],
+          "no-reference-import": true,
+          "prefer-conditional-expression": true,
+          "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type",
+            "check-typecast",
+            "check-type-operator",
+            "check-rest-spread"
+          ]
+        }
+      }
+    ],
     "arrow-parens": [
       "error",
       "as-needed"
@@ -85,27 +104,9 @@
       "string",
       "Boolean",
       "boolean",
-      "Undefined",
-      "undefined"
+      "Undefined"
     ],
     "id-match": "error",
-    /*
-    "import/no-extraneous-dependencies": [
-      "error",
-      {
-        "devDependencies": false
-      }
-    ], */
-    /*
-    "import/no-internal-modules": [
-      "error",
-      {
-        "allow": [
-          "strtok3/*",
-          "file-type/*"
-        ]
-      }
-    ],*/
     "import/order": "off",
     "max-classes-per-file": "off",
     "max-len": [
@@ -164,29 +165,6 @@
     "spaced-comment": "error",
     "use-isnan": "error",
     "valid-typeof": "off",
-    "@typescript-eslint/tslint/config": [
-      "error",
-      {
-        "rules": {
-          "jsdoc-format": [
-            true,
-            "check-multiline-start"
-          ],
-          "no-reference-import": true,
-          "prefer-conditional-expression": true,
-          "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type",
-            "check-typecast",
-            "check-type-operator",
-            "check-rest-spread"
-          ]
-        }
-      }
-    ]
+
   }
 }

--- a/lib/BufferTokenizer.ts
+++ b/lib/BufferTokenizer.ts
@@ -42,13 +42,13 @@ export class BufferTokenizer extends AbstractTokenizer {
    */
   public async peekBuffer(uint8Array: Uint8Array, options?: IReadChunkOptions): Promise<number> {
 
-    options = this.normalizeOptions(uint8Array, options);
+    const normOptions = this.normalizeOptions(uint8Array, options);
 
-    const bytes2read = Math.min(this.uint8Array.length - options.position, options.length);
-    if ((!options.mayBeLess) && bytes2read < options.length) {
+    const bytes2read = Math.min(this.uint8Array.length - normOptions.position, normOptions.length);
+    if ((!normOptions.mayBeLess) && bytes2read < normOptions.length) {
       throw new EndOfStreamError();
     } else {
-      uint8Array.set(this.uint8Array.subarray(options.position, options.position + bytes2read), options.offset);
+      uint8Array.set(this.uint8Array.subarray(normOptions.position, normOptions.position + bytes2read), normOptions.offset);
       return bytes2read;
     }
   }

--- a/lib/FsPromise.ts
+++ b/lib/FsPromise.ts
@@ -34,7 +34,7 @@ export async function close(fd: number): Promise<void> {
   });
 }
 
-export async function open(path: fs.PathLike, mode?: string): Promise<number> {
+export async function open(path: fs.PathLike, mode: fs.Mode): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     fs.open(path, mode, (err, fd) => {
       if (err)

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -1,6 +1,6 @@
 import { AbstractTokenizer } from './AbstractTokenizer';
 import { EndOfStreamError, StreamReader } from 'peek-readable';
-import * as Stream from 'stream';
+import { Readable } from 'stream';
 import { IFileInfo, IReadChunkOptions } from './types';
 
 const maxBufferSize = 256000;
@@ -9,7 +9,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
 
   private streamReader: StreamReader;
 
-  public constructor(stream: Stream.Readable, fileInfo?: IFileInfo) {
+  public constructor(stream: Readable, fileInfo?: IFileInfo) {
     super(fileInfo);
     this.streamReader = new StreamReader(stream);
   }
@@ -24,47 +24,27 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
 
   /**
    * Read buffer from tokenizer
-   * @param buffer - Target buffer to fill with data read from the tokenizer-stream
+   * @param uint8Array - Target Uint8Array to fill with data read from the tokenizer-stream
    * @param options - Read behaviour options
    * @returns Promise with number of bytes read
    */
-  public async readBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number> {
-
-    // const _offset = position ? position : this.position;
-    // debug(`readBuffer ${_offset}...${_offset + length - 1}`);
-
-    let offset = 0;
-    let length = buffer.length;
-    if (options) {
-
-      if (Number.isInteger(options.length)) {
-        length = options.length;
-      } else {
-        length -= options.offset || 0;
-      }
-
-      if (options.position) {
-        const skipBytes = options.position - this.position;
-        if (skipBytes > 0) {
-          await this.ignore(skipBytes);
-          return this.readBuffer(buffer, options);
-        } else if (skipBytes < 0) {
-          throw new Error('`options.position` must be equal or greater than `tokenizer.position`');
-        }
-      }
-
-      if (options.offset) {
-        offset = options.offset;
-      }
+  public async readBuffer(uint8Array: Uint8Array, options?: IReadChunkOptions): Promise<number> {
+    const normOptions = this.normalizeOptions(uint8Array, options);
+    const skipBytes = normOptions.position - this.position;
+    if (skipBytes > 0) {
+      await this.ignore(skipBytes);
+      return this.readBuffer(uint8Array, options);
+    } else if (skipBytes < 0) {
+      throw new Error('`options.position` must be equal or greater than `tokenizer.position`');
     }
 
-    if (length === 0) {
+    if (normOptions.length === 0) {
       return 0;
     }
 
-    const bytesRead = await this.streamReader.read(buffer, offset, length);
+    const bytesRead = await this.streamReader.read(uint8Array, normOptions.offset, normOptions.length);
     this.position += bytesRead;
-    if ((!options || !options.mayBeLess) && bytesRead < length) {
+    if ((!options || !options.mayBeLess) && bytesRead < normOptions.length) {
       throw new EndOfStreamError();
     }
     return bytesRead;
@@ -78,31 +58,31 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
    */
   public async peekBuffer(uint8Array: Uint8Array, options?: IReadChunkOptions): Promise<number> {
 
-    options = this.normalizeOptions(uint8Array, options);
+    const normOptions = this.normalizeOptions(uint8Array, options);
     let bytesRead = 0;
 
-    if (options.position) {
-      const skipBytes = options.position - this.position;
+    if (normOptions.position) {
+      const skipBytes = normOptions.position - this.position;
       if (skipBytes > 0) {
-        const skipBuffer = new Uint8Array(options.length + skipBytes);
-        bytesRead = await this.peekBuffer(skipBuffer, {mayBeLess: options.mayBeLess});
-        uint8Array.set(skipBuffer.subarray(skipBytes), options.offset);
+        const skipBuffer = new Uint8Array(normOptions.length + skipBytes);
+        bytesRead = await this.peekBuffer(skipBuffer, {mayBeLess: normOptions.mayBeLess});
+        uint8Array.set(skipBuffer.subarray(skipBytes), normOptions.offset);
         return bytesRead - skipBytes;
       } else if (skipBytes < 0) {
         throw new Error('Cannot peek from a negative offset in a stream');
       }
     }
 
-    if (options.length > 0) {
+    if (normOptions.length > 0) {
       try {
-        bytesRead = await this.streamReader.peek(uint8Array, options.offset, options.length);
+        bytesRead = await this.streamReader.peek(uint8Array, normOptions.offset, normOptions.length);
       } catch (err) {
         if (options && options.mayBeLess && err instanceof EndOfStreamError) {
           return 0;
         }
         throw err;
       }
-      if ((!options.mayBeLess) && bytesRead < options.length) {
+      if ((!normOptions.mayBeLess) && bytesRead < normOptions.length) {
         throw new EndOfStreamError();
       }
     }

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,5 +1,5 @@
 import { ReadStreamTokenizer } from './ReadStreamTokenizer';
-import * as Stream from 'stream';
+import { Readable } from 'stream';
 import { BufferTokenizer } from './BufferTokenizer';
 import { IFileInfo } from './types';
 export { EndOfStreamError } from 'peek-readable';
@@ -13,7 +13,7 @@ export { IToken, IGetToken } from '@tokenizer/token';
  * @param fileInfo - Pass the file information, like size and MIME-type of the correspnding stream.
  * @returns ReadStreamTokenizer
  */
-export function fromStream(stream: Stream.Readable, fileInfo?: IFileInfo): ReadStreamTokenizer {
+export function fromStream(stream: Readable, fileInfo?: IFileInfo): ReadStreamTokenizer {
   fileInfo = fileInfo ? fileInfo : {};
   return new ReadStreamTokenizer(stream, fileInfo);
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
-import * as Stream from 'stream';
-
+import { Readable } from 'stream';
 import * as fs from './FsPromise';
 import { ReadStreamTokenizer } from './ReadStreamTokenizer';
 import * as core from './core';
@@ -15,7 +14,7 @@ export { IToken, IGetToken } from '@tokenizer/token';
  * @param fileInfo - Pass additional file information to the tokenizer
  * @returns Tokenizer
  */
-export async function fromStream(stream: Stream.Readable, fileInfo?: core.IFileInfo): Promise<ReadStreamTokenizer> {
+export async function fromStream(stream: Readable, fileInfo?: core.IFileInfo): Promise<ReadStreamTokenizer> {
   fileInfo = fileInfo ? fileInfo : {};
   if ((stream as any).path) {
     const stat = await fs.stat((stream as any).path);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,7 +46,6 @@ export interface IReadChunkOptions {
   mayBeLess?: boolean;
 }
 
-
 /**
  * The tokenizer allows us to read or peek from the tokenizer-stream.
  * The tokenizer-stream is an abstraction of a stream, file or Buffer.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "eslint lib test --ext .ts --ignore-pattern *.d.ts",
     "lint-md": "remark -u preset-lint-recommended .",
     "lint": "npm run lint-md && npm run eslint",
+    "fix": "eslint lib test --ext .ts --ignore-pattern *.d.ts --fix",
     "test": "mocha --require ts-node/register --require source-map-support/register --full-trace test/test.ts",
     "test-coverage": "nyc npm run test",
     "send-coveralls": "nyc report --reporter=text-lcov | coveralls",
@@ -68,7 +69,7 @@
   },
   "dependencies": {
     "@tokenizer/token": "^0.3.0",
-    "peek-readable": "^4.0.0"
+    "peek-readable": "^4.0.1"
   },
   "keywords": [
     "tokenizer",

--- a/test/test.ts
+++ b/test/test.ts
@@ -494,7 +494,7 @@ for (const tokenizerType of tokenizerTests) {
 
     });
 
-    it('Transparency', async function() {
+    it('Transparency', async function () {
 
       this.timeout(5000);
 
@@ -512,17 +512,12 @@ for (const tokenizerType of tokenizerTests) {
       const rst = await tokenizerType.loadTokenizer(testFile);
       let expected = 0;
 
-      function readByte() {
-        return rst.readNumber(Token.UINT8)
-          .then(v => {
-            assert.strictEqual(v, expected % 255, 'offset=' + expected);
-            ++expected;
-            return readByte();
-          });
-      }
-
       try {
-        await readByte();
+        do {
+          const v = await rst.readNumber(Token.UINT8);
+          assert.strictEqual(v, expected % 255, 'offset=' + expected);
+          ++expected;
+        } while (true);
       } catch (err) {
         assert.instanceOf(err, EndOfStreamError);
         assert.strictEqual(expected, size, 'total number of parsed bytes');
@@ -650,6 +645,8 @@ for (const tokenizerType of tokenizerTests) {
 
     it('number', async () => {
       const tokenizer = await tokenizerType.loadTokenizer('test3.dat');
+      assert.isDefined(tokenizer.fileInfo, 'tokenizer.fileInfo');
+      // @ts-ignore
       await tokenizer.ignore(tokenizer.fileInfo.size - 4);
       const x = await tokenizer.peekNumber(Token.INT32_BE);
       assert.strictEqual(x, 33752069);
@@ -657,6 +654,8 @@ for (const tokenizerType of tokenizerTests) {
 
     it('should throw an Error if we reach EOF while peeking a number', async () => {
       const tokenizer = await tokenizerType.loadTokenizer('test3.dat');
+      assert.isDefined(tokenizer.fileInfo, 'tokenizer.fileInfo');
+      // @ts-ignore
       await tokenizer.ignore(tokenizer.fileInfo.size - 3);
       try {
         const x = await tokenizer.peekNumber(Token.INT32_BE);
@@ -851,5 +850,3 @@ it('should determine the file size using a file stream', async () => {
   assert.isDefined(tokenizer.fileInfo, '`fileInfo` should be defined');
   assert.strictEqual(tokenizer.fileInfo.size, 16, 'fileInfo.size');
 });
-
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "inlineSources": false,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES2017"
+    "target": "ES2017",
+    "strict": true
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,10 +2718,10 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-peek-readable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.0.tgz#b024ef391c86136eba0ae9df3ff4f966a09e9a7e"
-  integrity sha512-kLbU4cz6h86poGVBKgAVMpFmD47nX04fPPQNKnv9fuj+IJZYkEBjsYAVu5nDbZWx0ZsWwWlMzeG90zQa5KLBaA==
+peek-readable@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.1.tgz#9a045f291db254111c3412c1ce4fec27ddd4d202"
+  integrity sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- Improve initialization of options
- Simplify import requirements.
- Update to [peek-readable@v4.0.1](https://github.com/Borewit/peek-readable/releases/tag/v4.0.1), also compiled with strict mode