### PR TITLE
feat: Goodbye, node.js Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Returns, via a promise, a [*tokenizer*](#tokenizer) which can be used to parse a
 ```js
 import * as strtok3 from 'strtok3';
 import * as Token from 'token-types';
-    
+
 (async () => {
 
   const tokenizer = await strtok3.fromFile("somefile.bin");
@@ -68,7 +68,7 @@ import * as Token from 'token-types';
     console.log(`My number: ${myNumber}`);
   } finally {
     tokenizer.close(); // Close the file
-  } 
+  }
 })();
 
 ```
@@ -106,7 +106,7 @@ Returns a [*tokenizer*](#tokenizer) which can be used to parse the provided buff
 
 ```js
 import * as strtok3 from 'strtok3';
-    
+
 const tokenizer = strtok3.fromBuffer(buffer);
 
 tokenizer.readToken(Token.UINT8).then(myUint8Number => {
@@ -115,7 +115,7 @@ tokenizer.readToken(Token.UINT8).then(myUint8Number => {
 ```
 
 ## Tokenizer
-The tokenizer allows us to *read* or *peek* from the *tokenizer-stream*. The *tokenizer-stream* is an abstraction of a [stream](https://nodejs.org/api/stream.html), file or [Buffer](https://nodejs.org/api/buffer.html).
+The tokenizer allows us to *read* or *peek* from the *tokenizer-stream*. The *tokenizer-stream* is an abstraction of a [stream](https://nodejs.org/api/stream.html), file or [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).
 It can also be translated in chunked reads, as done in [@tokenizer/http](https://github.com/Borewit/tokenizer-http);
 
 What is the difference with Nodejs.js stream?
@@ -133,7 +133,7 @@ Optional attribute describing the file information, see [IFileInfo](#IFileInfo)
 Pointer to the current position in the [*tokenizer*](#tokenizer) stream.
 If a *position* is provided to a *read* or *peek* method, is should be, at least, equal or greater than this value.
 
-### Tokenizer methods 
+### Tokenizer methods
 
 There are two kind of methods:
 1. *read* methods: used to read a *token* of [Buffer](https://nodejs.org/api/buffer.html) from the [*tokenizer*](#tokenizer). The position of the *tokenizer-stream* will advance with the size of the token.
@@ -200,7 +200,7 @@ Return value `Promise<number>` Promise with number peeked from the *tokenizer-st
 
 #### Method `tokenizer.ignore()`
 
-Advanse the offset pointer with the number of bytes provided. 
+Advance the offset pointer with the number of bytes provided.
 `ignore(length)`
 
 | Parameter  | Type   | Description                                                          |
@@ -234,14 +234,14 @@ File information interface which describes the underlying file, each attribute i
 
 | Attribute | Type    | Description                                                                                       |
 |-----------|---------|---------------------------------------------------------------------------------------------------|
-| size      | number  | File size in bytes                                                                                | 
+| size      | number  | File size in bytes                                                                                |
 | mimeType  | number  | [MIME-type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of file. |
 | path      | number  | File path                                                                                         |
 | url       | boolean | File URL                                                                                          |
 
 ## Token
 
-The *token* is basically a description what to read form the [*tokenizer-stream*](#tokenizer). 
+The *token* is basically a description what to read form the [*tokenizer-stream*](#tokenizer).
 A basic set of *token types* can be found here: [*token-types*](https://github.com/Borewit/token-types).
 
 A token is something which implements the following interface:
@@ -258,7 +258,7 @@ export interface IGetToken<T> {
    * @param buf Buffer to read the decoded value from
    * @param off Decode offset
    */
-  get(buf: Buffer, off: number): T;
+  get(buf: Uint8Array, off: number): T;
 }
 ```
 The *tokenizer* reads `token.len` bytes from the *tokenizer-stream* into a Buffer.
@@ -286,7 +286,7 @@ import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
   const response = await fetch(url);
   const readableWebStream = response.body; // Web-API readable stream
   const nodeStream = new ReadableWebToNodeStream(readableWebStream); // convert to Node.js readable stream
-  
+
   const tokenizer = strtok3core.fromStream(nodeStream); // And we now have tokenizer in a web environment
 })();
 ```

--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -1,7 +1,6 @@
 import { ITokenizer, IFileInfo, IReadChunkOptions } from './types.js';
 import { EndOfStreamError } from 'peek-readable';
 import { IGetToken, IToken } from '@tokenizer/token';
-import { Buffer } from 'node:buffer';
 
 interface INormalizedReadChunkOptions extends IReadChunkOptions {
   offset: number;
@@ -51,7 +50,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @returns Promise with token data
    */
   public async readToken<Value>(token: IGetToken<Value>, position: number = this.position): Promise<Value> {
-    const uint8Array = Buffer.alloc(token.len);
+    const uint8Array = new Uint8Array(token.len);
     const len = await this.readBuffer(uint8Array, {position});
     if (len < token.len)
       throw new EndOfStreamError();
@@ -65,7 +64,7 @@ export abstract class AbstractTokenizer implements ITokenizer {
    * @returns Promise with token data
    */
   public async peekToken<Value>(token: IGetToken<Value>, position: number = this.position): Promise<Value> {
-    const uint8Array = Buffer.alloc(token.len);
+    const uint8Array = new Uint8Array(token.len);
     const len = await this.peekBuffer(uint8Array, {position});
     if (len < token.len)
       throw new EndOfStreamError();

--- a/lib/FsPromise.ts
+++ b/lib/FsPromise.ts
@@ -56,9 +56,9 @@ export async function read(fd: number, buffer: Uint8Array, offset: number, lengt
   });
 }
 
-export async function writeFile(path: fs.PathLike, data: Buffer | string): Promise<void> {
+export async function writeFile(path: fs.PathLike, data: Uint8Array | string, options: fs.WriteFileOptions = null): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    fs.writeFile(path, data, err => {
+    fs.writeFile(path, data, options, err => {
       if (err)
         reject(err);
       else
@@ -67,12 +67,12 @@ export async function writeFile(path: fs.PathLike, data: Buffer | string): Promi
   });
 }
 
-export function writeFileSync(path: fs.PathLike, data: Buffer | string): void {
+export function writeFileSync(path: fs.PathLike, data: Uint8Array | string): void {
   fs.writeFileSync(path, data);
 }
 
-export async function readFile(path: fs.PathLike): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
+export async function readFile(path: fs.PathLike): Promise<Uint8Array> {
+  return new Promise<Uint8Array>((resolve, reject) => {
     fs.readFile(path, (err, buffer) => {
       if (err)
         reject(err);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,7 +68,7 @@ export interface ITokenizer {
    * @param options - Read behaviour options
    * @returns Promise with number of bytes read
    */
-  peekBuffer(buffer: Buffer, options?: IReadChunkOptions): Promise<number>;
+  peekBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number>;
 
   /**
    * Peek (read ahead) buffer from tokenizer
@@ -76,7 +76,7 @@ export interface ITokenizer {
    * @param options - Additional read options
    * @returns Promise with number of bytes read
    */
-  readBuffer(buffer: Buffer, options?: IReadChunkOptions): Promise<number>;
+  readBuffer(buffer: Uint8Array, options?: IReadChunkOptions): Promise<number>;
 
   /**
    * Peek a token from the tokenizer-stream.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "remark-preset-lint-recommended": "^7.0.0",
     "token-types": "^5.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "uint8array-extras": "^1.2.0"
   },
   "dependencies": {
     "@tokenizer/token": "^0.3.0",

--- a/test/test.ts
+++ b/test/test.ts
@@ -7,7 +7,7 @@ import { FileTokenizer } from '../lib/FileTokenizer.js';
 import { EndOfStreamError } from 'peek-readable';
 import { PassThrough } from 'node:stream';
 import mocha from 'mocha';
-import { Buffer } from 'node:buffer';
+import { stringToUint8Array, uint8ArrayToString } from 'uint8array-extras';
 
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -27,7 +27,7 @@ function getResourcePath(testFile: string) {
 
 async function getTokenizerWithData(testData: string, test: ITokenizerTest): Promise<strtok3.ITokenizer> {
   const testPath = getResourcePath('tmp.dat');
-  await fs.writeFile(testPath, Buffer.from(testData, 'latin1'));
+  await fs.writeFile(testPath, testData, { encoding: 'latin1' });
   return test.loadTokenizer('tmp.dat');
 }
 
@@ -59,72 +59,72 @@ for (const tokenizerType of tokenizerTests) {
     describe('tokenizer read options', () => {
 
       it('option.offset', async () => {
-        const buf = Buffer.alloc(7);
+        const buf = new Uint8Array(7);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.readBuffer(buf, {length: 6, offset: 1}), 6);
       });
 
       it('option.length', async () => {
-        const buf = Buffer.alloc(7);
+        const buf = new Uint8Array(7);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.readBuffer(buf, {length: 2}), 2);
       });
 
       it('default length', async () => {
-        const buf = Buffer.alloc(6);
+        const buf = new Uint8Array(6);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.readBuffer(buf, {offset: 1}), 5, 'default length = buffer.length - option.offset');
       });
 
       it('option.maybeLess = true', async () => {
-        const buffer = Buffer.alloc(4);
+        const buffer = new Uint8Array(4);
         const rst = await getTokenizerWithData('\x89\x54\x40', tokenizerType);
         const len = await rst.readBuffer(buffer, {mayBeLess: true});
         assert.strictEqual(len, 3, 'should return 3 because no more bytes are available');
       });
 
       it('option.position', async () => {
-        const buffer = Buffer.alloc(5);
+        const buffer = new Uint8Array(5);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         const len = await rst.readBuffer(buffer, {position: 1});
         assert.strictEqual(len, 5, 'return value');
-        assert.strictEqual(buffer.toString('binary'), '\x02\x03\x04\x05\x06');
+        assert.strictEqual(uint8ArrayToString(buffer, 'latin1'), '\x02\x03\x04\x05\x06');
       });
     });
 
     describe('tokenizer peek options', () => {
 
       it('option.offset', async () => {
-        const buf = Buffer.alloc(7);
+        const buf = new Uint8Array(7);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.peekBuffer(buf, {length: 6, offset: 1}), 6);
       });
 
       it('option.length', async () => {
-        const buf = Buffer.alloc(7);
+        const buf = new Uint8Array(7);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.peekBuffer(buf, {length: 2}), 2);
       });
 
       it('default length', async () => {
-        const buf = Buffer.alloc(6);
+        const buf = new Uint8Array(6);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         assert.strictEqual(await rst.peekBuffer(buf, {offset: 1}), 5, 'default length = buffer.length - option.offset');
       });
 
       it('option.maybeLess = true', async () => {
-        const buffer = Buffer.alloc(4);
+        const buffer = new Uint8Array(4);
         const rst = await getTokenizerWithData('\x89\x54\x40', tokenizerType);
         const len = await rst.peekBuffer(buffer, {mayBeLess: true});
         assert.strictEqual(len, 3, 'should return 3 because no more bytes are available');
       });
 
       it('option.position', async () => {
-        const buffer = Buffer.alloc(5);
+        const buffer = new Uint8Array(5);
         const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
         const len = await rst.peekBuffer(buffer, {position: 1});
         assert.strictEqual(len, 5, 'return value');
-        assert.strictEqual(buffer.toString('binary'), '\x02\x03\x04\x05\x06');
+        assert.strictEqual(uint8ArrayToString(buffer, 'latin1'), '\x02\x03\x04\x05\x06');
       });
 
     });
@@ -175,7 +175,7 @@ for (const tokenizerType of tokenizerTests) {
 
       const rst = await getTokenizerWithData('\x05peter', tokenizerType);
 
-      const buf = Buffer.alloc(4);
+      const buf = new Uint8Array(4);
 
       // should decode UINT8 from chunk
       assert.strictEqual(rst.position, 0);
@@ -197,16 +197,16 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode signed 8-bit integer (INT8)', () => {
 
-        const b = Buffer.alloc(1);
+        const b = new Uint8Array(1);
 
         Token.INT8.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00');
 
         Token.INT8.put(b, 0, 0x22);
-        assert.strictEqual(b.toString('binary'), '\x22');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x22');
 
         Token.INT8.put(b, 0, -0x22);
-        assert.strictEqual(b.toString('binary'), '\xde');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xde');
       });
 
       it('should decode signed 8-bit integer (INT8)', async () => {
@@ -235,16 +235,16 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode signed 16-bit big-endian integer (INT16_BE)', () => {
 
-        const b = Buffer.alloc(2);
+        const b = new Uint8Array(2);
 
         Token.INT16_BE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00');
 
         Token.INT16_BE.put(b, 0, 0x0f0b);
-        assert.strictEqual(b.toString('binary'), '\x0f\x0b');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x0f\x0b');
 
         Token.INT16_BE.put(b, 0, -0x0f0b);
-        assert.strictEqual(b.toString('binary'), '\xf0\xf5');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xf0\xf5');
       });
 
       it('should decode signed 16-bit big-endian integer (INT16_BE)', async () => {
@@ -269,16 +269,16 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode signed 24-bit big-endian integer (INT24_BE)', async () => {
 
-        const b = Buffer.alloc(3);
+        const b = new Uint8Array(3);
 
         Token.INT24_BE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00');
 
         Token.INT24_BE.put(b, 0, 0x0f0ba0);
-        assert.strictEqual(b.toString('binary'), '\x0f\x0b\xa0');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x0f\x0b\xa0');
 
         Token.INT24_BE.put(b, 0, -0x0f0bcc);
-        assert.strictEqual(b.toString('binary'), '\xf0\xf4\x34');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xf0\xf4\x34');
       });
 
       it('should decode signed 24-bit big-endian integer (INT24_BE)', async () => {
@@ -304,16 +304,16 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode signed 32-bit big-endian integer (INT32_BE)', () => {
 
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
 
         Token.INT32_BE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00\x00');
 
         Token.INT32_BE.put(b, 0, 0x0f0bcca0);
-        assert.strictEqual(b.toString('binary'), '\x0f\x0b\xcc\xa0');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x0f\x0b\xcc\xa0');
 
         Token.INT32_BE.put(b, 0, -0x0f0bcca0);
-        assert.strictEqual(b.toString('binary'), '\xf0\xf4\x33\x60');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xf0\xf4\x33\x60');
       });
 
       it('should decode signed 32-bit big-endian integer (INT32_BE)', async () => {
@@ -337,13 +337,13 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode signed 8-bit big-endian integer (INT8)', () => {
 
-        const b = Buffer.alloc(1);
+        const b = new Uint8Array(1);
 
         Token.UINT8.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00');
 
         Token.UINT8.put(b, 0, 0xff);
-        assert.strictEqual(b.toString('binary'), '\xff');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xff');
       });
 
       it('should decode unsigned 8-bit integer (UINT8)', async () => {
@@ -364,25 +364,25 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode unsigned 16-bit big-endian integer (UINT16_LE)', () => {
 
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
 
         Token.UINT16_LE.put(b, 0, 0x00);
         Token.UINT16_LE.put(b, 2, 0xffaa);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\xaa\xff');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\xaa\xff');
       });
 
       it('should encode unsigned 16-bit little-endian integer (UINT16_BE)', () => {
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
         Token.UINT16_BE.put(b, 0, 0xf);
         Token.UINT16_BE.put(b, 2, 0xffaa);
-        assert.strictEqual(b.toString('binary'), '\x00\x0f\xff\xaa');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x0f\xff\xaa');
       });
 
       it('should encode unsigned 16-bit mixed little/big-endian integers', () => {
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
         Token.UINT16_BE.put(b, 0, 0xffaa);
         Token.UINT16_LE.put(b, 2, 0xffaa);
-        assert.strictEqual(b.toString('binary'), '\xff\xaa\xaa\xff');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xff\xaa\xaa\xff');
       });
 
       it('should decode unsigned mixed 16-bit big/little-endian integer', async () => {
@@ -407,30 +407,30 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode unsigned 24-bit little-endian integer (UINT24_LE)', () => {
 
-        const b = Buffer.alloc(3);
+        const b = new Uint8Array(3);
 
         Token.UINT24_LE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00');
 
         Token.UINT24_LE.put(b, 0, 0xff);
-        assert.strictEqual(b.toString('binary'), '\xff\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xff\x00\x00');
 
         Token.UINT24_LE.put(b, 0, 0xaabbcc);
-        assert.strictEqual(b.toString('binary'), '\xcc\xbb\xaa');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xcc\xbb\xaa');
       });
 
       it('should encode unsigned 24-bit big-endian integer (UINT24_BE)', () => {
 
-        const b = Buffer.alloc(3);
+        const b = new Uint8Array(3);
 
         Token.UINT24_BE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00');
 
         Token.UINT24_BE.put(b, 0, 0xff);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\xff');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\xff');
 
         Token.UINT24_BE.put(b, 0, 0xaabbcc);
-        assert.strictEqual(b.toString('binary'), '\xaa\xbb\xcc');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xaa\xbb\xcc');
       });
 
       it('should decode signed 24-bit big/little-endian integer (UINT24_LE/INT24_BE)', async () => {
@@ -455,30 +455,30 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should encode unsigned 32-bit little-endian integer (UINT32_LE)', () => {
 
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
 
         Token.UINT32_LE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00\x00');
 
         Token.UINT32_LE.put(b, 0, 0xff);
-        assert.strictEqual(b.toString('binary'), '\xff\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xff\x00\x00\x00');
 
         Token.UINT32_LE.put(b, 0, 0xaabbccdd);
-        assert.strictEqual(b.toString('binary'), '\xdd\xcc\xbb\xaa');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xdd\xcc\xbb\xaa');
       });
 
       it('should encode unsigned 32-bit big-endian integer (INT32_BE)', () => {
 
-        const b = Buffer.alloc(4);
+        const b = new Uint8Array(4);
 
         Token.UINT32_BE.put(b, 0, 0x00);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00\x00');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00\x00');
 
         Token.UINT32_BE.put(b, 0, 0xff);
-        assert.strictEqual(b.toString('binary'), '\x00\x00\x00\xff');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\x00\x00\x00\xff');
 
         Token.UINT32_BE.put(b, 0, 0xaabbccdd);
-        assert.strictEqual(b.toString('binary'), '\xaa\xbb\xcc\xdd');
+        assert.strictEqual(uint8ArrayToString(b, 'latin1'), '\xaa\xbb\xcc\xdd');
       });
 
       it('should decode unsigned 32-bit little/big-endian integer (UINT32_LE/UINT32_BE)', async () => {
@@ -508,7 +508,7 @@ for (const tokenizerType of tokenizerTests) {
       this.timeout(5000);
 
       const size = 10 * 1024;
-      const buf = Buffer.alloc(size);
+      const buf = new Uint8Array(size);
 
       for (let i = 0; i < size; ++i) {
         buf[i] = i % 255;
@@ -583,42 +583,42 @@ for (const tokenizerType of tokenizerTests) {
     it('Overlapping peeks', async () => {
 
       const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05', tokenizerType);
-      const peekBuffer = Buffer.alloc(3);
-      const readBuffer = Buffer.alloc(1);
+      const peekBuffer = new Uint8Array(3);
+      const readBuffer = new Uint8Array(1);
 
       assert.strictEqual(0, rst.position);
       let len = await rst.peekBuffer(peekBuffer, {length: 3}); // Peek #1
       assert.strictEqual(3, len);
-      assert.deepEqual(peekBuffer, Buffer.from('\x01\x02\x03', 'binary'), 'Peek #1');
+      assert.deepEqual(peekBuffer, stringToUint8Array('\x01\x02\x03'), 'Peek #1');
       assert.strictEqual(rst.position, 0);
       len = await rst.readBuffer(readBuffer, {length: 1}); // Read #1
       assert.strictEqual(len, 1);
       assert.strictEqual(rst.position, 1);
-      assert.deepEqual(readBuffer, Buffer.from('\x01', 'binary'), 'Read #1');
+      assert.deepEqual(readBuffer, stringToUint8Array('\x01'), 'Read #1');
       len = await rst.peekBuffer(peekBuffer, {length: 3}); // Peek #2
       assert.strictEqual(len, 3);
       assert.strictEqual(rst.position, 1);
-      assert.deepEqual(peekBuffer, Buffer.from('\x02\x03\x04', 'binary'), 'Peek #2');
+      assert.deepEqual(peekBuffer, stringToUint8Array('\x02\x03\x04'), 'Peek #2');
       len = await rst.readBuffer(readBuffer, {length: 1}); // Read #2
       assert.strictEqual(len, 1);
       assert.strictEqual(rst.position, 2);
-      assert.deepEqual(readBuffer, Buffer.from('\x02', 'binary'), 'Read #2');
+      assert.deepEqual(readBuffer, stringToUint8Array('\x02'), 'Read #2');
       len = await rst.peekBuffer(peekBuffer, {length: 3}); // Peek #3
       assert.strictEqual(len, 3);
       assert.strictEqual(rst.position, 2);
-      assert.deepEqual(peekBuffer, Buffer.from('\x03\x04\x05', 'binary'), 'Peek #3');
+      assert.deepEqual(peekBuffer, stringToUint8Array('\x03\x04\x05'), 'Peek #3');
       len = await rst.readBuffer(readBuffer, {length: 1}); // Read #3
       assert.strictEqual(len, 1);
       assert.strictEqual(rst.position, 3);
-      assert.deepEqual(readBuffer, Buffer.from('\x03', 'binary'), 'Read #3');
+      assert.deepEqual(readBuffer, stringToUint8Array('\x03'), 'Read #3');
       len = await rst.peekBuffer(peekBuffer, {length: 2}); // Peek #4
       assert.strictEqual(len, 2, '3 bytes requested to peek, only 2 bytes left');
       assert.strictEqual(rst.position, 3);
-      assert.deepEqual(peekBuffer, Buffer.from('\x04\x05\x05', 'binary'), 'Peek #4');
+      assert.deepEqual(peekBuffer, stringToUint8Array('\x04\x05\x05'), 'Peek #4');
       len = await rst.readBuffer(readBuffer, {length: 1}); // Read #4
       assert.strictEqual(len, 1);
       assert.strictEqual(rst.position, 4);
-      assert.deepEqual(readBuffer, Buffer.from('\x04', 'binary'), 'Read #4');
+      assert.deepEqual(readBuffer, stringToUint8Array('\x04'), 'Read #4');
 
       await rst.close();
     });
@@ -722,7 +722,7 @@ for (const tokenizerType of tokenizerTests) {
 
         const stat = await fs.stat(getResourcePath(testFile));
         const tokenizer = await tokenizerType.loadTokenizer(testFile);
-        const buf = Buffer.alloc(stat.size);
+        const buf = new Uint8Array(stat.size);
         const bytesRead = await tokenizer.readBuffer(buf);
         assert.ok(typeof bytesRead === 'number', 'readBuffer promise should provide a number');
         assert.strictEqual(stat.size, bytesRead);
@@ -754,7 +754,7 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should throw an EOF if we read to buffer', async () => {
 
-        const buffer = Buffer.alloc(4);
+        const buffer = new Uint8Array(4);
 
         return getTokenizerWithData('\x89\x54\x40', tokenizerType).then(rst => {
           return rst.readBuffer(buffer).then(len => {
@@ -767,7 +767,7 @@ for (const tokenizerType of tokenizerTests) {
 
       it('should throw an EOF if we peek to buffer', async () => {
 
-        const buffer = Buffer.alloc(4);
+        const buffer = new Uint8Array(4);
         const rst = await getTokenizerWithData('\x89\x54\x40', tokenizerType);
         try {
           await rst.peekBuffer(buffer);
@@ -812,7 +812,7 @@ for (const tokenizerType of tokenizerTests) {
     });
 
     it('should be able to read 0 bytes from a file', async () => {
-      const bufZero = Buffer.alloc(0);
+      const bufZero = new Uint8Array(0);
       const tokenizer = await tokenizerType.loadTokenizer('test1.dat');
       await tokenizer.readBuffer(bufZero);
     });
@@ -829,7 +829,7 @@ describe('fromStream with mayBeLess flag', () => {
     stream.end();
 
     // Try to read 5 bytes from empty stream, with mayBeLess flag enabled
-    const buffer = Buffer.alloc(5);
+    const buffer = new Uint8Array(5);
     const bytesRead = await tokenizer.peekBuffer(buffer, {mayBeLess: true});
     assert.strictEqual(bytesRead, 0);
   });
@@ -842,7 +842,7 @@ describe('fromStream with mayBeLess flag', () => {
       stream.end();
 
       // Try to read 5 bytes from empty stream, with mayBeLess flag enabled
-      const buffer = Buffer.alloc(5);
+      const buffer = new Uint8Array(5);
       await tokenizer.peekBuffer(buffer, {mayBeLess: false});
     } catch (err) {
       if (err instanceof Error) {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,6 @@
 // Utility functions for testing
 import { Readable } from 'node:stream';
+import { stringToUint8Array } from 'uint8array-extras';
 
 /**
  * A mock stream implementation that breaks up provided data into
@@ -9,10 +10,10 @@ import { Readable } from 'node:stream';
 export class SourceStream extends Readable {
 
   public static FromString(str: string = ''): SourceStream {
-    return new SourceStream(Buffer.from(str, 'binary'));
+    return new SourceStream(stringToUint8Array(str));
   }
 
-  public constructor(private buf: Buffer) {
+  public constructor(private buf: Uint8Array) {
     super();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,11 +1777,6 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
-has-bigints@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
-  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1962,23 +1957,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
-is-bigint@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
-  integrity sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==
-
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   dependencies:
     binary-extensions "^2.0.0"
-
-is-boolean-object@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.1.tgz#3c0878f035cb821228d350d2e1e36719716a3de8"
-  integrity sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==
-  dependencies:
-    call-bind "^1.0.2"
 
 is-builtin-module@^3.2.1:
   version "3.2.1"
@@ -2056,11 +2039,6 @@ is-negative-zero@^2.0.3:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
 
-is-number-object@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.5.tgz#6edfaeed7950cff19afedce9fbfca9ee6dd289eb"
-  integrity sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==
-
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -2109,11 +2087,6 @@ is-shared-array-buffer@^1.0.2, is-shared-array-buffer@^1.0.3:
   dependencies:
     call-bind "^1.0.7"
 
-is-string@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
-  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
-
 is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -2126,13 +2099,6 @@ is-symbol@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
   dependencies:
     has-symbols "^1.0.0"
-
-is-symbol@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
-  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
-  dependencies:
-    has-symbols "^1.0.2"
 
 is-typed-array@^1.1.13:
   version "1.1.13"
@@ -3592,7 +3558,7 @@ spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3609,6 +3575,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -3670,7 +3645,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3905,6 +3887,11 @@ typescript@^5.5.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
 
+uint8array-extras@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.2.0.tgz#36a3138ba2d1c0bce9ab824f6f16bc783c20118f"
+  integrity sha512-+J8XoVf9Y/vyCz8Xp7kGRb6dVuC5qIIWibNrpIoYVcjJqBzdb+tbS2XunRO4dxPj0YGy1G+TvrQU2EYjF0LiBA==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -4136,17 +4123,6 @@ walk-up-path@^3.0.1:
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-3.0.1.tgz#c8d78d5375b4966c717eb17ada73dbd41490e886"
   integrity sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==
 
-which-boxed-primitive@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
-  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
-  dependencies:
-    is-bigint "^1.0.1"
-    is-boolean-object "^1.1.0"
-    is-number-object "^1.0.4"
-    is-string "^1.0.5"
-    is-symbol "^1.0.3"
-
 which-typed-array@^1.1.14, which-typed-array@^1.1.15:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.15.tgz#264859e9b11a649b388bfaaf4f767df1f779b38d"
@@ -4175,7 +4151,16 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Pretty straightforward converting the Buffer usage to Uint8Array.

This PR depends on:
- [x] [`uint8array-extras`](https://github.com/sindresorhus/uint8array-extras/pull/12) as a devDependency.

