### PR TITLE
Update dependencies strtok3 and peek-readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,14 +69,14 @@
     "mocha": "^10.5.2",
     "remark-cli": "^12.0.1",
     "remark-preset-lint-recommended": "^7.0.0",
-    "token-types": "^5.0.1",
+    "token-types": "^6.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.2",
     "uint8array-extras": "^1.2.0"
   },
   "dependencies": {
     "@tokenizer/token": "^0.3.0",
-    "peek-readable": "^5.0.0"
+    "peek-readable": "^5.1.1"
   },
   "keywords": [
     "tokenizer",


### PR DESCRIPTION
 - strtok3 version from 5.0.1 to [6.0.0](https://github.com/Borewit/token-types/releases/tag/v6.0.0)
 - peek-readable from 5.0.0 to [5.1.1](https://github.com/Borewit/peek-readable/releases/tag/v5.1.1)