### PR TITLE
Workaround for issue in Bun, which throws an error on 0 byte file read

### DIFF
--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -18,7 +18,7 @@ export class FileTokenizer extends AbstractTokenizer {
   public async readBuffer(uint8Array: Uint8Array, options?: IReadChunkOptions): Promise<number> {
     const normOptions = this.normalizeOptions(uint8Array, options);
     this.position = normOptions.position;
-    if (!normOptions.length) return 0;
+    if (normOptions.length === 0) return 0;
     const res = await this.fileHandle.read(uint8Array, normOptions.offset, normOptions.length, normOptions.position);
     this.position += res.bytesRead;
     if (res.bytesRead < normOptions.length && (!options || !options.mayBeLess)) {

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -18,6 +18,7 @@ export class FileTokenizer extends AbstractTokenizer {
   public async readBuffer(uint8Array: Uint8Array, options?: IReadChunkOptions): Promise<number> {
     const normOptions = this.normalizeOptions(uint8Array, options);
     this.position = normOptions.position;
+    if (!normOptions.length) return 0;
     const res = await this.fileHandle.read(uint8Array, normOptions.offset, normOptions.length, normOptions.position);
     this.position += res.bytesRead;
     if (res.bytesRead < normOptions.length && (!options || !options.mayBeLess)) {


### PR DESCRIPTION
While NodeJS accepts a  `filehandle.read()` with length 0, [Bun](https://github.com/oven-sh/bun) [throws a error](https://github.com/user-attachments/assets/e50ff126-4ffb-4bc7-ad2b-9666ffbea68d) right now

This PR is a workaround to, fixing [Bun](https://github.com/oven-sh/bun) compatibility.

Corresponding issue raised at Bun: https://github.com/oven-sh/bun/issues/13146

> [!NOTE] 
> I encountered this because [file-type](https://www.npmjs.com/package/file-type) depends on this package (file-type has 20m weekly downloads so weird that no one encountered this yet)


