### PR TITLE
Fix export typing `AnyWebByteStream`

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,16 +1,15 @@
+import type { Readable } from 'node:stream';
+import { StreamReader, WebStreamReader } from 'peek-readable';
+
 import { ReadStreamTokenizer } from './ReadStreamTokenizer.js';
 import { BufferTokenizer } from './BufferTokenizer.js';
-import { StreamReader, WebStreamReader } from 'peek-readable';
 import type { ITokenizerOptions } from './types.js';
-import type { ReadableStream as NodeReadableStream, ReadableStream } from 'node:stream/web';
-import type { Readable } from 'node:stream';
+import type { AnyWebByteStream } from './core.js';
 
-export { EndOfStreamError } from 'peek-readable';
+export { EndOfStreamError, type AnyWebByteStream } from 'peek-readable';
 export type { ITokenizer, IFileInfo, ITokenizerOptions, IReadChunkOptions, OnClose } from './types.js';
 export type { IToken, IGetToken } from '@tokenizer/token';
 export { AbstractTokenizer } from './AbstractTokenizer.js';
-
-export type AnyWebByteStream = NodeReadableStream<Uint8Array> | ReadableStream<Uint8Array>;
 
 /**
  * Construct ReadStreamTokenizer from given Stream.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,8 +4,7 @@ import { stat as fsStat } from 'node:fs/promises';
 import { type ITokenizerOptions, fromStream as coreFromStream } from './core.js';
 
 export { fromFile } from './FileTokenizer.js';
-export { EndOfStreamError, fromBuffer, fromWebStream, AbstractTokenizer} from './core.js';
-export type { ITokenizer, IFileInfo, ITokenizerOptions, IReadChunkOptions, OnClose, AnyWebByteStream} from './core.js';
+export * from './core.js';
 export type { IToken, IGetToken } from '@tokenizer/token';
 
 interface StreamWithFile extends Readable {


### PR DESCRIPTION
Related to #1144 , which did not actually exported the DOM type.

This takes the `AnyWebByteStream` typing from https://github.com/Borewit/peek-readable/pull/740.