### PR TITLE
Deprecate `option.offset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ Each attribute is optional:
 
 | Attribute | Type    | Description                                                                                                                                                                                                                   |
 |-----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| offset    | number  | The offset in the buffer to start writing at; if not provided, start at 0                                                                                                                                                     |
 | length    | number  | Requested number of bytes to read.                                                                                                                                                                                            |
 | position  | number  | Position where to peek from the file. If position is null, data will be read from the [current file position](#attribute-tokenizerposition). Position may not be less then [tokenizer.position](#attribute-tokenizerposition) |
 | mayBeLess | boolean | If and only if set, will not throw an EOF error if less then the requested *mayBeLess* could be read.                                                                                                                         |

--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -3,7 +3,6 @@ import type { IGetToken, IToken } from '@tokenizer/token';
 import { EndOfStreamError } from 'peek-readable';
 
 interface INormalizedReadChunkOptions extends IReadChunkOptions {
-  offset: number;
   length: number;
   position: number;
   mayBeLess?: boolean;
@@ -140,15 +139,13 @@ export abstract class AbstractTokenizer implements ITokenizer {
     if (options) {
       return {
         mayBeLess: options.mayBeLess === true,
-        offset: options.offset ? options.offset : 0,
-        length: options.length ? options.length : (uint8Array.length - (options.offset ? options.offset : 0)),
+        length: options.length ? options.length : uint8Array.length,
         position: options.position ? options.position : this.position
       };
     }
 
     return {
       mayBeLess: false,
-      offset: 0,
       length: uint8Array.length,
       position: this.position
     };

--- a/lib/BufferTokenizer.ts
+++ b/lib/BufferTokenizer.ts
@@ -50,7 +50,7 @@ export class BufferTokenizer extends AbstractTokenizer implements IRandomAccessT
     if ((!normOptions.mayBeLess) && bytes2read < normOptions.length) {
       throw new EndOfStreamError();
     }
-    uint8Array.set(this.uint8Array.subarray(normOptions.position, normOptions.position + bytes2read), normOptions.offset);
+    uint8Array.set(this.uint8Array.subarray(normOptions.position, normOptions.position + bytes2read));
     return bytes2read;
   }
 

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -39,7 +39,7 @@ export class FileTokenizer extends AbstractTokenizer implements IRandomAccessTok
     const normOptions = this.normalizeOptions(uint8Array, options);
     this.position = normOptions.position;
     if (normOptions.length === 0) return 0;
-    const res = await this.fileHandle.read(uint8Array, normOptions.offset, normOptions.length, normOptions.position);
+    const res = await this.fileHandle.read(uint8Array, 0, normOptions.length, normOptions.position);
     this.position += res.bytesRead;
     if (res.bytesRead < normOptions.length && (!options || !options.mayBeLess)) {
       throw new EndOfStreamError();
@@ -57,7 +57,7 @@ export class FileTokenizer extends AbstractTokenizer implements IRandomAccessTok
 
     const normOptions = this.normalizeOptions(uint8Array, options);
 
-    const res = await this.fileHandle.read(uint8Array, normOptions.offset, normOptions.length, normOptions.position);
+    const res = await this.fileHandle.read(uint8Array, 0, normOptions.length, normOptions.position);
     if ((!normOptions.mayBeLess) && res.bytesRead < normOptions.length) {
       throw new EndOfStreamError();
     }

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -37,7 +37,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
     if (normOptions.length === 0) {
       return 0;
     }
-    const bytesRead = await this.streamReader.read(uint8Array, normOptions.offset, normOptions.length);
+    const bytesRead = await this.streamReader.read(uint8Array, 0, normOptions.length);
     this.position += bytesRead;
     if ((!options || !options.mayBeLess) && bytesRead < normOptions.length) {
       throw new EndOfStreamError();
@@ -61,7 +61,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
       if (skipBytes > 0) {
         const skipBuffer = new Uint8Array(normOptions.length + skipBytes);
         bytesRead = await this.peekBuffer(skipBuffer, {mayBeLess: normOptions.mayBeLess});
-        uint8Array.set(skipBuffer.subarray(skipBytes), normOptions.offset);
+        uint8Array.set(skipBuffer.subarray(skipBytes));
         return bytesRead - skipBytes;
       }
       if (skipBytes < 0) {
@@ -71,7 +71,7 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
 
     if (normOptions.length > 0) {
       try {
-        bytesRead = await this.streamReader.peek(uint8Array, normOptions.offset, normOptions.length);
+        bytesRead = await this.streamReader.peek(uint8Array, 0, normOptions.length);
       } catch (err) {
         if (options?.mayBeLess && err instanceof EndOfStreamError) {
           return 0;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,11 +31,6 @@ export interface IRandomAccessFileInfo extends IFileInfo {
 export interface IReadChunkOptions {
 
   /**
-   * The offset in the buffer to start writing at; default is 0
-   */
-  offset?: number;
-
-  /**
    * Number of bytes to read.
    */
   length?: number;

--- a/test/test.ts
+++ b/test/test.ts
@@ -88,7 +88,7 @@ describe('Matrix tests', () => {
           it('option.offset', async () => {
             const buf = new Uint8Array(7);
             const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
-            assert.strictEqual(await rst.readBuffer(buf, {length: 6, offset: 1}), 6);
+            assert.strictEqual(await rst.readBuffer(buf.subarray(1), {length: 6}), 6);
             await rst.close();
           });
 
@@ -102,7 +102,7 @@ describe('Matrix tests', () => {
           it('default length', async () => {
             const buf = new Uint8Array(6);
             const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
-            assert.strictEqual(await rst.readBuffer(buf, {offset: 1}), 5, 'default length = buffer.length - option.offset');
+            assert.strictEqual(await rst.readBuffer(buf.subarray(1)), 5, 'default length = buffer.length - option.offset');
             await rst.close();
           });
 
@@ -130,7 +130,7 @@ describe('Matrix tests', () => {
           it('option.offset', async () => {
             const buf = new Uint8Array(7);
             const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
-            assert.strictEqual(await rst.peekBuffer(buf, {length: 6, offset: 1}), 6);
+            assert.strictEqual(await rst.peekBuffer(buf.subarray(1), {length: 6}), 6);
             await rst.close();
           });
 
@@ -144,7 +144,7 @@ describe('Matrix tests', () => {
           it('default length', async () => {
             const buf = new Uint8Array(6);
             const rst = await getTokenizerWithData('\x01\x02\x03\x04\x05\x06', tokenizerType);
-            assert.strictEqual(await rst.peekBuffer(buf, {offset: 1}), 5, 'default length = buffer.length - option.offset');
+            assert.strictEqual(await rst.peekBuffer(buf.subarray(1)), 5, 'default length = buffer.length - option.offset');
             await rst.close();
           });
 


### PR DESCRIPTION
You should use `Uint8Array.subarray(offset)` instead