### PR TITLE
Update peek-readable to `^6.1.0`.

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -5,7 +5,7 @@ import { ReadStreamTokenizer } from './ReadStreamTokenizer.js';
 import { BufferTokenizer } from './BufferTokenizer.js';
 import type { ITokenizerOptions } from './types.js';
 
-export { EndOfStreamError, type AnyWebByteStream } from 'peek-readable';
+export { EndOfStreamError, AbortError, type AnyWebByteStream } from 'peek-readable';
 export type { ITokenizer, IRandomAccessTokenizer, IFileInfo, IRandomAccessFileInfo, ITokenizerOptions, IReadChunkOptions, OnClose } from './types.js';
 export type { IToken, IGetToken } from '@tokenizer/token';
 export { AbstractTokenizer } from './AbstractTokenizer.js';

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@tokenizer/token": "^0.3.0",
-    "peek-readable": "^6.0.2"
+    "peek-readable": "^6.1.0"
   },
   "keywords": [
     "tokenizer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,10 +2492,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"peek-readable@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "peek-readable@npm:6.0.2"
-  checksum: 10c0/1ea609773ce86371dbfe1aa969da5090e6c19ef997216633f8d0c4530647f4d518e40e7d9a1ca0d358af7df91343b96d1bc4daa0e792bb12a1dfcdd1e8774a24
+"peek-readable@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "peek-readable@npm:6.1.0"
+  checksum: 10c0/e98fa8ad3908889a4db7c8bebe7e57c9ca6cfdda3206591cce330a8ad1681c05fab15ee7871ebe1c52d0d1982c561039e88aa915f1dd4ae203593944e2a59ee2
   languageName: node
   linkType: hard
 
@@ -3136,7 +3136,7 @@ __metadata:
     chai-as-promised: "npm:^8.0.1"
     del-cli: "npm:^6.0.0"
     mocha: "npm:^11.1.0"
-    peek-readable: "npm:^6.0.2"
+    peek-readable: "npm:^6.1.0"
     remark-cli: "npm:^12.0.1"
     remark-preset-lint-recommended: "npm:^7.0.1"
     token-types: "npm:^6.0.0"


### PR DESCRIPTION
Changes:
1. Update peek-readable to `^6.1.0`.
2. Export `AbortError`, thrown by `peek-readable`.