### PR TITLE
CI: Add integration tests for Bun (CoreJavaScript engine)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: CI
 on:
   pull_request:
     branches: [ "master" ]
@@ -44,8 +44,8 @@ jobs:
             test/**/*.js
             test/**/*.js.map
 
-  test:
-    name: "Node.js version matrix test"
+  test-nodejs:
+    name: "Test with Node.js (V8)"
     runs-on: ubuntu-latest
     needs: build
 
@@ -61,7 +61,7 @@ jobs:
       - name: 'Checkout the repository'
         uses: actions/checkout@v4
 
-      - name: Test with Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -84,11 +84,56 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.test_number }}
+          flag-name: run-node-${{ matrix.test_number }}
+          parallel: true
+
+  test-bun:
+    name: "Test with Bun (JavaScriptCore)"
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        bun-version: [1.2]
+
+    env:
+      YARN_IGNORE_NODE: 1
+
+    steps:
+
+      - name: 'Checkout the repository'
+        uses: actions/checkout@v4
+
+      - name: Setup Bun ${{ matrix.bun-version }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Unit tests with Bun ${{ matrix.bun-version }}
+        run: yarn run test-coverage
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-bun-${{ matrix.test_number }}
           parallel: true
 
   finish:
-    needs: test
+    needs:
+      - test-nodejs
+      - test-bun
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Node.js CI](https://github.com/Borewit/strtok3/actions/workflows/nodejs-ci.yml/badge.svg?branch=master)](https://github.com/Borewit/strtok3/actions/workflows/nodejs-ci.yml?query=branch%3Amaster)
+[![Node.js CI](https://github.com/Borewit/strtok3/actions/workflows/ci.yml/badge.svg)](https://github.com/Borewit/strtok3/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Borewit/strtok3/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/Borewit/strtok3/actions/workflows/codeql.yml)
 [![NPM version](https://badge.fury.io/js/strtok3.svg)](https://npmjs.org/package/strtok3)
 [![npm downloads](http://img.shields.io/npm/dm/strtok3.svg)](https://npmcharts.com/compare/strtok3,token-types?start=1200&interval=30)
@@ -35,7 +35,7 @@ npm install strtok3
 Starting with version 7, the module has migrated from [CommonJS](https://en.wikipedia.org/wiki/CommonJS) to [pure ECMAScript Module (ESM)](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 The distributed JavaScript codebase is compliant with the [ECMAScript 2020 (11th Edition)](https://en.wikipedia.org/wiki/ECMAScript_version_history#11th_Edition_%E2%80%93_ECMAScript_2020) standard.
 
-Requires a modern browser or Node.js ≥ 18 engine.
+Requires a modern browser, Node.js (V8) ≥ 18 engine or Bun (JavaScriptCore) ≥ 1.2.
 
 For TypeScript CommonJs backward compatibility, you can use [load-esm](https://github.com/Borewit/load-esm).
 


### PR DESCRIPTION
Add integration for [Bum](https://bun.sh/) 1.2. As Bum is based on [JavaScriptCore](https://github.com/apple-opensource/JavaScriptCore), this also provides confidence there is compatibility with the Apple Safari web browser.