### PR TITLE
Merge peek-readable package into strtok3

### DIFF
--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -1,6 +1,6 @@
 import type { ITokenizer, IFileInfo, IReadChunkOptions, OnClose, ITokenizerOptions } from './types.js';
 import type { IGetToken, IToken } from '@tokenizer/token';
-import { EndOfStreamError } from 'peek-readable';
+import { EndOfStreamError } from './stream/index.js';
 
 interface INormalizedReadChunkOptions extends IReadChunkOptions {
   length: number;

--- a/lib/BufferTokenizer.ts
+++ b/lib/BufferTokenizer.ts
@@ -1,5 +1,5 @@
 import type {ITokenizerOptions, IReadChunkOptions, IRandomAccessFileInfo, IRandomAccessTokenizer} from './types.js';
-import { EndOfStreamError } from 'peek-readable';
+import { EndOfStreamError } from './stream/index.js';
 import { AbstractTokenizer } from './AbstractTokenizer.js';
 
 export class BufferTokenizer extends AbstractTokenizer implements IRandomAccessTokenizer {

--- a/lib/FileTokenizer.ts
+++ b/lib/FileTokenizer.ts
@@ -1,5 +1,5 @@
 import { AbstractTokenizer } from './AbstractTokenizer.js';
-import { EndOfStreamError } from 'peek-readable';
+import { EndOfStreamError } from './stream/index.js';
 import type {IRandomAccessTokenizer, IRandomAccessFileInfo, IReadChunkOptions, ITokenizerOptions} from './types.js';
 import { type FileHandle, open as fsOpen } from 'node:fs/promises';
 

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -1,5 +1,5 @@
 import { AbstractTokenizer } from './AbstractTokenizer.js';
-import { EndOfStreamError, type IStreamReader } from 'peek-readable';
+import { EndOfStreamError, type IStreamReader } from './stream/index.js';
 import type {IFileInfo, IReadChunkOptions, ITokenizerOptions} from './types.js';
 
 const maxBufferSize = 256000;

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,11 +1,11 @@
 import type { Readable } from 'node:stream';
-import { StreamReader, makeWebStreamReader, type AnyWebByteStream } from 'peek-readable';
+import { StreamReader, makeWebStreamReader, type AnyWebByteStream } from './stream/index.js';
 
 import { ReadStreamTokenizer } from './ReadStreamTokenizer.js';
 import { BufferTokenizer } from './BufferTokenizer.js';
 import type { ITokenizerOptions } from './types.js';
 
-export { EndOfStreamError, AbortError, type AnyWebByteStream } from 'peek-readable';
+export { EndOfStreamError, AbortError, type AnyWebByteStream } from './stream/index.js';
 export type { ITokenizer, IRandomAccessTokenizer, IFileInfo, IRandomAccessFileInfo, ITokenizerOptions, IReadChunkOptions, OnClose } from './types.js';
 export type { IToken, IGetToken } from '@tokenizer/token';
 export { AbstractTokenizer } from './AbstractTokenizer.js';

--- a/lib/stream/AbstractStreamReader.ts
+++ b/lib/stream/AbstractStreamReader.ts
@@ -1,0 +1,126 @@
+import { EndOfStreamError, AbortError } from "./Errors.js";
+
+
+export interface IStreamReader {
+  /**
+   * Peak ahead (peek) from stream. Subsequent read or peeks will return the same data.
+   * @param uint8Array - Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - Allow the read to complete, without the buffer being fully filled (length may be smaller)
+   * @returns Number of bytes peeked. If `maybeLess` is set, this shall be the `uint8Array.length`.
+   */
+  peek(uint8Array: Uint8Array, mayBeLess?: boolean): Promise<number>;
+
+  /**
+   * Read from stream the stream.
+   * @param uint8Array - Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - Allow the read to complete, without the buffer being fully filled (length may be smaller)
+   * @returns Number of actually bytes read. If `maybeLess` is set, this shall be the `uint8Array.length`.
+   */
+  read(uint8Array: Uint8Array, mayBeLess?: boolean): Promise<number>;
+
+  /*
+   * Close underlying resources, claims.
+   */
+  close(): Promise<void>;
+
+  /**
+   * Abort any active asynchronous operation are active, abort those before they may have completed.
+   */
+  abort(): Promise<void>;
+}
+
+export abstract class AbstractStreamReader implements IStreamReader {
+
+  protected endOfStream = false;
+  protected interrupted = false;
+
+  /**
+   * Store peeked data
+   * @type {Array}
+   */
+  protected peekQueue: Uint8Array[] = [];
+
+  public async peek(uint8Array: Uint8Array, mayBeLess = false): Promise<number> {
+    const bytesRead = await this.read(uint8Array, mayBeLess);
+    this.peekQueue.push(uint8Array.subarray(0, bytesRead)); // Put read data back to peek buffer
+    return bytesRead;
+  }
+
+  public async read(buffer: Uint8Array, mayBeLess = false): Promise<number> {
+    if (buffer.length === 0) {
+      return 0;
+    }
+
+    let bytesRead = this.readFromPeekBuffer(buffer);
+    if (!this.endOfStream) {
+      bytesRead += await this.readRemainderFromStream(buffer.subarray(bytesRead), mayBeLess);
+    }
+    if (bytesRead === 0) {
+      throw new EndOfStreamError();
+    }
+    return bytesRead;
+  }
+
+  /**
+   * Read chunk from stream
+   * @param buffer - Target Uint8Array (or Buffer) to store data read from stream in
+   * @returns Number of bytes read
+   */
+  protected readFromPeekBuffer(buffer: Uint8Array): number {
+
+    let remaining = buffer.length;
+    let bytesRead = 0;
+    // consume peeked data first
+    while (this.peekQueue.length > 0 && remaining > 0) {
+      const peekData = this.peekQueue.pop(); // Front of queue
+      if (!peekData) throw new Error('peekData should be defined');
+      const lenCopy = Math.min(peekData.length, remaining);
+      buffer.set(peekData.subarray(0, lenCopy), bytesRead);
+      bytesRead += lenCopy;
+      remaining -= lenCopy;
+      if (lenCopy < peekData.length) {
+        // remainder back to queue
+        this.peekQueue.push(peekData.subarray(lenCopy));
+      }
+    }
+    return bytesRead;
+  }
+
+  public async readRemainderFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number> {
+
+    let bytesRead = 0;
+    // Continue reading from stream if required
+    while (bytesRead < buffer.length && !this.endOfStream) {
+      if(this.interrupted) {
+        throw new AbortError();
+      }
+
+      const chunkLen = await this.readFromStream(buffer.subarray(bytesRead), mayBeLess);
+      if (chunkLen === 0)
+        break;
+      bytesRead += chunkLen;
+    }
+    if (!mayBeLess && bytesRead < buffer.length) {
+      throw new EndOfStreamError();
+    }
+    return bytesRead;
+  }
+
+  /**
+   * Read from stream
+   * @param buffer - Target Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - If true, may fill the buffer partially
+   * @protected Bytes read
+   */
+  protected abstract readFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number>
+
+  /**
+   * abort synchronous operations
+   */
+  public abstract close(): Promise<void>;
+
+  /**
+   * Abort any active asynchronous operation are active, abort those before they may have completed.
+   */
+  public abstract abort(): Promise<void>;
+}

--- a/lib/stream/Deferred.ts
+++ b/lib/stream/Deferred.ts
@@ -1,0 +1,13 @@
+export class Deferred<T> {
+
+  public promise: Promise<T>;
+  public resolve: (value: T) => void = () => null;
+  public reject: (reason: Error) => void = () => null;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.reject = reject;
+      this.resolve = resolve;
+    });
+  }
+}

--- a/lib/stream/Errors.ts
+++ b/lib/stream/Errors.ts
@@ -1,0 +1,18 @@
+export const defaultMessages = 'End-Of-Stream';
+
+/**
+ * Thrown on read operation of the end of file or stream has been reached
+ */
+export class EndOfStreamError extends Error {
+  constructor() {
+    super(defaultMessages);
+    this.name = "EndOfStreamError";
+  }
+}
+
+export class AbortError extends Error {
+  constructor(message = "The operation was aborted") {
+    super(message);
+    this.name = "AbortError";
+  }
+}

--- a/lib/stream/StreamReader.ts
+++ b/lib/stream/StreamReader.ts
@@ -1,0 +1,99 @@
+import type { Readable } from 'node:stream';
+import { AbortError, } from './Errors.js';
+import { Deferred } from './Deferred.js';
+import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+interface IReadRequest {
+  buffer: Uint8Array,
+  mayBeLess: boolean,
+  deferred: Deferred<number>
+}
+
+/**
+ * Node.js Readable Stream Reader
+ * Ref: https://nodejs.org/api/stream.html#readable-streams
+ */
+export class StreamReader extends AbstractStreamReader {
+
+  /**
+   * Deferred used for postponed read request (as not data is yet available to read)
+   */
+  private deferred: Deferred<number> | null = null;
+
+  public constructor(private s: Readable) {
+    super();
+    if (!s.read || !s.once) {
+      throw new Error('Expected an instance of stream.Readable');
+    }
+    this.s.once('end', () => {
+      this.endOfStream = true;
+      if (this.deferred) {
+        this.deferred.resolve(0);
+      }
+    });
+    this.s.once('error', err => this.reject(err));
+    this.s.once('close', () => this.abort());
+  }
+
+  /**
+   * Read chunk from stream
+   * @param buffer Target Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - If true, may fill the buffer partially
+   * @returns Number of bytes read
+   */
+  protected async readFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number> {
+
+    if (buffer.length === 0) return 0;
+
+    const readBuffer = this.s.read(buffer.length);
+
+    if (readBuffer) {
+      buffer.set(readBuffer);
+      return readBuffer.length;
+    }
+
+    const request = {
+      buffer,
+      mayBeLess,
+      deferred: new Deferred<number>()
+    };
+    this.deferred = request.deferred;
+    this.s.once('readable', () => {
+      this.readDeferred(request);
+    });
+    return request.deferred.promise;
+  }
+
+  /**
+   * Process deferred read request
+   * @param request Deferred read request
+   */
+  private readDeferred(request: IReadRequest) {
+    const readBuffer = this.s.read(request.buffer.length);
+    if (readBuffer) {
+      request.buffer.set(readBuffer);
+      request.deferred.resolve(readBuffer.length);
+      this.deferred = null;
+    } else {
+      this.s.once('readable', () => {
+        this.readDeferred(request);
+      });
+    }
+  }
+
+  private reject(err: Error) {
+    this.interrupted = true;
+    if (this.deferred) {
+      this.deferred.reject(err);
+      this.deferred = null;
+    }
+  }
+
+  public async abort(): Promise<void> {
+    this.reject(new AbortError());
+  }
+
+  async close(): Promise<void> {
+    return this.abort();
+  }
+}

--- a/lib/stream/WebStreamByobReader.ts
+++ b/lib/stream/WebStreamByobReader.ts
@@ -1,0 +1,33 @@
+import { WebStreamReader } from './WebStreamReader.js';
+
+/**
+ * Read from a WebStream using a BYOB reader
+ * Reference: https://nodejs.org/api/webstreams.html#class-readablestreambyobreader
+ */
+export class WebStreamByobReader extends WebStreamReader {
+
+  /**
+   * Read from stream
+   * @param buffer - Target Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - If true, may fill the buffer partially
+   * @protected Bytes read
+   */
+  protected async readFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number> {
+
+    if (buffer.length === 0) return 0;
+
+    // @ts-ignore
+    const result = await this.reader.read(new Uint8Array(buffer.length), {min: mayBeLess ? undefined : buffer.length});
+
+    if (result.done) {
+      this.endOfStream = result.done;
+    }
+
+    if(result.value) {
+      buffer.set(result.value);
+      return result.value.length;
+    }
+
+    return 0;
+  }
+}

--- a/lib/stream/WebStreamDefaultReader.ts
+++ b/lib/stream/WebStreamDefaultReader.ts
@@ -1,0 +1,74 @@
+import { EndOfStreamError } from './Errors.js';
+import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+export class WebStreamDefaultReader extends AbstractStreamReader {
+  private buffer: Uint8Array | null = null; // Internal buffer to store excess data
+
+  public constructor(private reader: ReadableStreamDefaultReader<Uint8Array>) {
+    super();
+  }
+
+  /**
+   * Copy chunk to target, and store the remainder in this.buffer
+   */
+  private writeChunk(target: Uint8Array, chunk: Uint8Array): number {
+    const written = Math.min(chunk.length, target.length);
+    target.set(chunk.subarray(0, written));
+
+    // Adjust the remainder of the buffer
+    if (written < chunk.length) {
+      this.buffer = chunk.subarray(written);
+    } else {
+      this.buffer = null;
+    }
+    return written;
+  }
+
+  /**
+   * Read from stream
+   * @param buffer - Target Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - If true, may fill the buffer partially
+   * @protected Bytes read
+   */
+  protected async readFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number> {
+
+    if (buffer.length === 0) return 0;
+
+    let totalBytesRead = 0;
+
+    // Serve from the internal buffer first
+    if (this.buffer) {
+      totalBytesRead += this.writeChunk(buffer, this.buffer);
+    }
+
+    // Continue reading from the stream if more data is needed
+    while (totalBytesRead < buffer.length && !this.endOfStream) {
+      const result = await this.reader.read();
+
+      if (result.done) {
+        this.endOfStream = true;
+        break;
+      }
+
+      if (result.value) {
+        totalBytesRead += this.writeChunk(buffer.subarray(totalBytesRead), result.value);
+      }
+    }
+
+    if (totalBytesRead === 0 && this.endOfStream) {
+      throw new EndOfStreamError();
+    }
+
+    return totalBytesRead;
+  }
+
+  public abort(): Promise<void> {
+    this.interrupted = true;
+    return this.reader.cancel();
+  }
+
+  public async close(): Promise<void> {
+    await this.abort();
+    this.reader.releaseLock();
+  }
+}

--- a/lib/stream/WebStreamReader.ts
+++ b/lib/stream/WebStreamReader.ts
@@ -1,0 +1,24 @@
+import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+export abstract class WebStreamReader extends AbstractStreamReader {
+
+  public constructor(protected reader: ReadableStreamDefaultReader | ReadableStreamBYOBReader) {
+    super();
+  }
+
+  /**
+   * Read from stream
+   * @param buffer - Target Uint8Array (or Buffer) to store data read from stream in
+   * @param mayBeLess - If true, may fill the buffer partially
+   * @protected Bytes read
+   */
+  protected abstract readFromStream(buffer: Uint8Array, mayBeLess: boolean): Promise<number>;
+
+  public async abort(): Promise<void> {
+    return this.close();
+  }
+
+  public async close(): Promise<void> {
+    this.reader.releaseLock();
+  }
+}

--- a/lib/stream/WebStreamReaderFactory.ts
+++ b/lib/stream/WebStreamReaderFactory.ts
@@ -1,0 +1,22 @@
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
+import { WebStreamByobReader } from './WebStreamByobReader.js';
+import { WebStreamDefaultReader } from './WebStreamDefaultReader.js';
+
+export type AnyWebByteStream = NodeReadableStream<Uint8Array> | ReadableStream<Uint8Array>;
+
+export function makeWebStreamReader(stream: AnyWebByteStream): WebStreamByobReader | WebStreamDefaultReader {
+  try {
+    const reader = stream.getReader({mode: "byob"});
+    if (reader instanceof ReadableStreamDefaultReader) {
+      // Fallback to default reader in case `mode: byob` is ignored
+      return new WebStreamDefaultReader(reader as ReadableStreamDefaultReader<Uint8Array>);
+    }
+    return new WebStreamByobReader(reader);
+  } catch(error) {
+    if (error instanceof TypeError) {
+      // Fallback to default reader in case `mode: byob` rejected by a `TypeError`
+      return new WebStreamDefaultReader(stream.getReader());
+    }
+    throw error;
+  }
+}

--- a/lib/stream/index.ts
+++ b/lib/stream/index.ts
@@ -1,0 +1,6 @@
+export { AbortError, EndOfStreamError } from './Errors.js';
+export { StreamReader } from './StreamReader.js';
+export { WebStreamByobReader } from './WebStreamByobReader.js';
+export { WebStreamDefaultReader } from './WebStreamDefaultReader.js';
+export type { IStreamReader } from './AbstractStreamReader.js';
+export { type AnyWebByteStream, makeWebStreamReader } from './WebStreamReaderFactory.js'

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "url": "https://github.com/Borewit/strtok3/issues"
   },
   "dependencies": {
-    "@tokenizer/token": "^0.3.0",
-    "peek-readable": "^7.0.0"
+    "@tokenizer/token": "^0.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,6 @@
-import { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import * as fs from 'node:fs/promises';
-import { createReadStream } from 'node:fs';
+import { createReadStream, type ReadStream } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,16 +13,17 @@ import {
   fromStream,
   fromWebStream,
   type ITokenizer,
-  type IRandomAccessTokenizer
+  type IRandomAccessTokenizer, AbortError
 } from '../lib/index.js';
 import Path from 'node:path';
-import { EndOfStreamError } from 'peek-readable';
+import { EndOfStreamError, type IStreamReader, makeWebStreamReader, StreamReader } from '../lib/stream/index.js';
 
 import mocha from 'mocha';
 import { stringToUint8Array } from 'uint8array-extras';
 
-import { DelayedStream, makeByteReadableStreamFromFile } from './util.js';
+import { DelayedStream, SourceStream, makeByteReadableStreamFromFile, stringToReadableStream } from './util.js';
 import process from 'node:process';
+import { EventEmitter } from "node:events";
 
 use(chaiAsPromised);
 
@@ -38,6 +39,12 @@ interface ITokenizerTest {
   randomRead: boolean;
 }
 
+interface StreamFactorySuite {
+  description: string;
+  isDefaultWebReader?: true;
+  fromString: (input: string, delay?: number) => IStreamReader;
+}
+
 function getResourcePath(testFile: string) {
   return Path.join(__dirname, 'resources', testFile);
 }
@@ -46,6 +53,19 @@ async function getTokenizerWithData(testData: string, test: ITokenizerTest, dela
   const testPath = getResourcePath('tmp.dat');
   await fs.writeFile(testPath, testData, {encoding: 'latin1'});
   return test.loadTokenizer('tmp.dat', delay, abortSignal);
+}
+
+const latin1TextDecoder = new TextDecoder('latin1');
+
+function closeNodeStream(stream: ReadStream): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    stream.close(err => {
+      if(err)
+        reject(err);
+      else
+        resolve();
+    });
+  })
 }
 
 describe('Matrix tests', () => {
@@ -1050,6 +1070,400 @@ describe('fromStream with mayBeLess flag', () => {
       }
     }
     assert.fail('Should throw End-Of-Stream error');
+  });
+
+  describe('stream', () => {
+
+    const streamFactories: StreamFactorySuite[] = [{
+      description: 'Node.js StreamReader',
+      fromString: (input, delay) => new StreamReader(new SourceStream(input, delay))
+    }, {
+      description: 'WebStream BYOB Reader',
+      fromString: (input, delay) => makeWebStreamReader(stringToReadableStream(input, false, delay))
+    }, {
+      description: 'WebStream Default Reader',
+      isDefaultWebReader: true,
+      fromString: (input, delay) => makeWebStreamReader(stringToReadableStream(input, true, delay ))
+    }];
+
+    streamFactories
+      //.filter((q, n) => n===1)
+      .forEach(factory => {
+        describe(factory.description, () => {
+
+          it('should be able to handle 0 byte read request', async () => {
+            const streamReader = factory.fromString('abcdefg');
+
+            const buf = new Uint8Array(0);
+            const bytesRead = await streamReader.read(buf.subarray(0, 0));
+            assert.strictEqual(bytesRead, 0, 'Should return');
+          });
+
+          it('read from a streamed data chunk', async () => {
+            const streamReader = factory.fromString('\x05peter');
+
+            let uint8Array: Uint8Array;
+            let bytesRead: number;
+
+            // read only one byte from the chunk
+            uint8Array = new Uint8Array(1);
+            bytesRead = await streamReader.read(uint8Array.subarray(0, 1));
+            assert.strictEqual(bytesRead, 1, 'Should read exactly one byte');
+            assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+
+            // should decode string from chunk
+            uint8Array = new Uint8Array(5);
+            bytesRead = await streamReader.read(uint8Array.subarray(0, 5));
+            assert.strictEqual(bytesRead, 5, 'Should read 5 bytes');
+            assert.strictEqual(new TextDecoder('latin1').decode(uint8Array), 'peter');
+
+            // should reject at the end of the stream
+            uint8Array = new Uint8Array(1);
+            try {
+              await streamReader.read(uint8Array.subarray(0, 1));
+              assert.fail('Should reject due to end-of-stream');
+            } catch (err) {
+              assert.instanceOf(err, EndOfStreamError);
+            }
+          });
+
+          describe('peek', () => {
+
+            it('should be able to read a peeked chunk', async () => {
+
+              const streamReader = factory.fromString('\x05peter');
+
+              const uint8Array = new Uint8Array(1);
+
+              let bytesRead = await streamReader.peek(uint8Array.subarray(0, 1));
+              assert.strictEqual(bytesRead, 1, 'Should peek exactly one byte');
+              assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+              bytesRead = await streamReader.read(uint8Array.subarray(0, 1));
+              assert.strictEqual(bytesRead, 1, 'Should re-read the peaked byte');
+              assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+            });
+
+            it('should be able to read a larger chunk overlapping the peeked chunk', async () => {
+
+              const streamReader = factory.fromString('\x05peter');
+
+              const uint8Array = new Uint8Array(6).fill(0);
+
+              let bytesRead = await streamReader.peek(uint8Array.subarray(0, 1));
+              assert.strictEqual(bytesRead, 1, 'Should peek exactly one byte');
+              assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+              bytesRead = await streamReader.read(uint8Array.subarray(0, 6));
+              assert.strictEqual(bytesRead, 6, 'Should overlap the peaked byte');
+              assert.strictEqual(latin1TextDecoder.decode(uint8Array.buffer), '\x05peter');
+            });
+
+            it('should be able to read a smaller chunk then the overlapping peeked chunk', async () => {
+
+              const streamReader = factory.fromString('\x05peter');
+
+              const uint8Array = new Uint8Array(6).fill(0);
+
+              let bytesRead = await streamReader.peek(uint8Array.subarray(0, 2));
+              assert.strictEqual(bytesRead, 2, 'Should peek 2 bytes');
+              assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+              bytesRead = await streamReader.read(uint8Array.subarray(0, 1));
+              assert.strictEqual(bytesRead, 1, 'Should read only 1 byte');
+              assert.strictEqual(uint8Array[0], 5, '0x05 == 5');
+              bytesRead = await streamReader.read(uint8Array.subarray(1, 6));
+              assert.strictEqual(bytesRead, 5, 'Should read remaining 5 byte');
+              assert.strictEqual(latin1TextDecoder.decode(uint8Array), '\x05peter');
+            });
+
+            it('should be able to handle overlapping peeks', async () => {
+
+              const streamReader = factory.fromString('\x01\x02\x03\x04\x05');
+
+              const peekBufferShort = new Uint8Array(1);
+              const peekBuffer = new Uint8Array(3);
+              const readBuffer = new Uint8Array(1);
+
+              let len = await streamReader.peek(peekBuffer.subarray(0, 3)); // Peek #1
+              assert.equal(3, len);
+              assert.strictEqual(latin1TextDecoder.decode(peekBuffer), '\x01\x02\x03', 'Peek #1');
+              len = await streamReader.peek(peekBufferShort.subarray(0, 1)); // Peek #2
+              assert.equal(1, len);
+              assert.strictEqual(latin1TextDecoder.decode(peekBufferShort), '\x01', 'Peek #2');
+              len = await streamReader.read(readBuffer.subarray(0, 1)); // Read #1
+              assert.equal(len, 1);
+              assert.strictEqual(latin1TextDecoder.decode(readBuffer), '\x01', 'Read #1');
+              len = await streamReader.peek(peekBuffer.subarray(0, 3)); // Peek #3
+              assert.equal(len, 3);
+              assert.strictEqual(latin1TextDecoder.decode(peekBuffer), '\x02\x03\x04', 'Peek #3');
+              len = await streamReader.read(readBuffer.subarray(0, 1)); // Read #2
+              assert.equal(len, 1);
+              assert.strictEqual(latin1TextDecoder.decode(readBuffer), '\x02', 'Read #2');
+              len = await streamReader.peek(peekBuffer.subarray(0, 3)); // Peek #3
+              assert.equal(len, 3);
+              assert.strictEqual(latin1TextDecoder.decode(peekBuffer), '\x03\x04\x05', 'Peek #3');
+              len = await streamReader.read(readBuffer.subarray(0, 1)); // Read #3
+              assert.equal(len, 1);
+              assert.strictEqual(latin1TextDecoder.decode(readBuffer), '\x03', 'Read #3');
+              len = await streamReader.peek(peekBuffer.subarray(0, 2)); // Peek #4
+              assert.equal(len, 2, '3 bytes requested to peek, only 2 bytes left');
+              assert.strictEqual(latin1TextDecoder.decode(peekBuffer), '\x04\x05\x05', 'Peek #4');
+              len = await streamReader.read(readBuffer.subarray(0, 1)); // Read #4
+              assert.equal(len, 1);
+              assert.strictEqual(latin1TextDecoder.decode(readBuffer), '\x04', 'Read #4');
+            });
+          });
+
+          describe('EndOfStream Error', () => {
+
+            it('should not throw an EndOfStream Error if we read exactly until the end of the stream', async () => {
+
+              const streamReader = factory.fromString('123');
+
+              const res = new Uint8Array(3);
+
+              const len = await streamReader.peek(res, false);
+              assert.equal(len, 3);
+            });
+
+            it('should return a partial result from a stream if EOF is reached', async () => {
+
+              const streamReader = factory.fromString('123');
+
+              const res = new Uint8Array(4);
+
+              let len = await streamReader.peek(res, true);
+              assert.equal(len, 3, 'should indicate only 3 bytes are actually peeked');
+              len = await streamReader.read(res, true);
+              assert.equal(len, 3, 'should indicate only 3 bytes are actually read');
+            });
+
+          });
+
+          describe('Handle delayed read', () => {
+
+            it('handle delay', async ()=> {
+              const streamReader = factory.fromString('123', 500);
+              const res = new Uint8Array(3);
+              const promise = streamReader.read(res.subarray(0, 3));
+              assert.strictEqual(await promise, 3);
+            });
+
+            it('abort async operation', async function() {
+              if (process.versions.bun) {
+                this.skip(); // https://github.com/oven-sh/bun/issues/17008
+              }
+              const fileReadStream = factory.fromString('123', 500);
+              const res = new Uint8Array(3);
+              const promise = fileReadStream.read(res.subarray(0, 3));
+              await fileReadStream.abort();
+              await expect(promise).to.be.rejectedWith(Error)
+            });
+
+          });
+
+        });
+      });
+  });
+
+  describe('file-stream', () => {
+
+    const fileSize = 5;
+    const uint8Array = new Uint8Array(17);
+
+    it('should return a partial size, if full length cannot be read', async () => {
+      const fileReadStream = createReadStream(new URL('resources/test3.dat', import.meta.url));
+      const streamReader = new StreamReader(fileReadStream);
+      const actualRead = await streamReader.read(uint8Array.subarray(0, 17), true);
+      assert.strictEqual(actualRead, fileSize);
+      fileReadStream.close();
+    });
+
+  });
+
+  describe('exception', () => {
+
+    const uint8Array = new Uint8Array(17);
+
+    it('handle stream closed', async () => {
+      const fileReadStream = createReadStream(new URL('resources/test3.dat', import.meta.url));
+      const streamReader = new StreamReader(fileReadStream);
+      fileReadStream.close(); // Sabotage stream
+
+      try {
+        await streamReader.read(uint8Array.subarray(0, 17));
+        assert.fail('Should throw an exception');
+      } catch (err: unknown) {
+        assert.instanceOf(err, AbortError);
+      }
+    });
+
+    it('handle stream error', async () => {
+
+      const fileReadStream = createReadStream(new URL('resources/file-does-not-exist', import.meta.url));
+      const streamReader = new StreamReader(fileReadStream);
+      try {
+        try {
+          await streamReader.read(uint8Array.subarray(0, 17));
+          assert.fail('Should throw an exception');
+        } catch (err) {
+          if (err instanceof Error) {
+            assert.strictEqual((err as Error & { code: string }).code, 'ENOENT');
+          } else {
+            assert.fail('Should throw an exception');
+          }
+        }
+      } finally {
+        await streamReader.close();
+      }
+    });
+
+  });
+
+  describe('Node.js StreamReader', () => {
+
+    it('should throw an exception if constructor argument is not a stream', () => {
+
+      const not_a_stream = new EventEmitter();
+
+      expect(() => {
+        new StreamReader(not_a_stream as unknown as Readable);
+      }).to.throw('Expected an instance of stream.Readable');
+    });
+
+    describe('disjoint', () => {
+
+      const TESTTAB = [
+        [1, 1, 1, 1],
+        [4],
+        [1, 1, 1, 1, 4],
+        [2, 2],
+        [3, 3, 3, 3],
+        [1, 4, 3],
+        [5],
+        [5, 5, 5]
+      ];
+
+      // A net.Stream workalike that emits the indefinitely repeating string
+      // '\x01\x02\x03\x04' in chunks specified by the 'lens' array param.
+      class LensSourceStream extends Readable {
+
+        public nvals: number;
+        private buf: Uint8Array;
+
+        public constructor(private lens: number[]) {
+
+          super();
+
+          let len = 0;
+
+          for (const v of lens) {
+            len += v;
+          }
+
+          this.nvals = Math.floor(len / 4);
+
+          const string = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+          this.buf = new Uint8Array((this.nvals + 1)* string.length);
+          for (let i = 0; i < this.nvals + 1; i++) {
+            this.buf.set(string, i * string.length);
+          }
+        }
+
+        public _read() {
+          if (this.lens.length === 0) {
+            this.push(null); // push the EOF-signaling `null` chunk
+            return;
+          }
+
+          const l = this.lens.shift();
+          const b = this.buf.slice(0, l);
+          this.buf = this.buf.slice(l, this.buf.length);
+
+          this.push(b);
+        }
+      }
+
+      const t = TESTTAB.shift();
+      if (!t) return;
+      const s = new LensSourceStream(t);
+
+      const uint8Array = new Uint8Array(4);
+
+      const run = async (): Promise<void> => {
+        const sb = new StreamReader(s);
+        try {
+          const bytesRead = await sb.read(uint8Array.subarray(0, 4));
+          assert.strictEqual(bytesRead, 4);
+          assert.strictEqual(new DataView(uint8Array.buffer).getUint32(0, false), 16909060);
+          if (--s.nvals > 0) {
+            return run();
+          }
+        } finally {
+          await sb.close();
+        }
+      };
+
+      it('should parse disjoint', () => {
+        return run();
+      });
+
+    });
+
+    describe('file-stream', () => {
+
+      const fileSize = 5;
+      const uint8Array = new Uint8Array(17);
+
+      it('should return a partial size, if full length cannot be read', async () => {
+        const fileReadStream = createReadStream(new URL('resources/test3.dat', import.meta.url));
+        try {
+          const streamReader = new StreamReader(fileReadStream);
+          try {
+            const actualRead = await streamReader.read(uint8Array.subarray(0, 17), true);
+            assert.strictEqual(actualRead, fileSize);
+          } finally {
+            await streamReader.close();
+          }
+        } finally {
+          await closeNodeStream(fileReadStream);
+        }
+      });
+    });
+
+    describe('abort() should release stream-lock', () => {
+
+      it('BYOB WebStreamReader', async () => {
+
+        const readableStream = stringToReadableStream('abc', false);
+        try {
+          assert.isFalse(readableStream.locked, 'stream is unlocked before initializing tokenizer');
+
+          const webStreamReader = makeWebStreamReader(readableStream);
+          assert.isTrue(readableStream.locked, 'stream is locked after initializing tokenizer');
+
+          await webStreamReader.close();
+          assert.isFalse(readableStream.locked, 'stream is unlocked after closing tokenizer');
+        } finally {
+          await readableStream.cancel();
+        }
+
+      });
+
+      it('Default WebStreamReader', async () => {
+
+        const readableStream = stringToReadableStream('abc', true);
+        try {
+          assert.isFalse(readableStream.locked, 'stream is unlocked before initializing tokenizer');
+
+          const webStreamReader = makeWebStreamReader(readableStream);
+          assert.isTrue(readableStream.locked, 'stream is locked after initializing tokenizer');
+
+          await webStreamReader.close();
+          assert.isFalse(readableStream.locked, 'stream is unlocked after closing tokenizer');
+        } finally {
+          await readableStream.cancel();
+        }
+      });
+    });
   });
 
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -68,3 +68,48 @@ export class DelayedStream extends Readable {
   }
 }
 
+/**
+ * A mock Node.js readable-stream, using string to read from
+ */
+export class SourceStream extends Readable {
+
+  private readonly buf: Uint8Array;
+
+  constructor(private str = '', private delay = 0) {
+    super();
+
+    this.buf = new TextEncoder().encode(str);
+  }
+
+  public _read() {
+    setTimeout(() => {
+      this.push(this.buf);
+      this.push(null); // Signal end of stream
+    }, this.delay);
+  }
+}
+
+// Function to convert a string to a BYOB ReadableStream
+function stringReadableStream(inputString: string, delay = 0): ReadableStream<Uint8Array> {
+  // Convert the string to a Uint8Array using TextEncoder
+
+  const nodeReadable = new SourceStream(inputString, delay);
+  return makeByteReadableStreamFromNodeReadable(nodeReadable) as ReadableStream<Uint8Array>;
+}
+
+export function stringToReadableStream(inputString: string, forceDefault: boolean, delay?: number): ReadableStream<Uint8Array> {
+  const stream = stringReadableStream(inputString, delay);
+  const _getReader = stream.getReader.bind(stream);
+
+  // @ts-ignore
+  stream.getReader = (options?: { mode?: string }) => {
+    if (forceDefault) {
+      // Force returning the default reader
+      return _getReader(); // Call without options for a default reader
+    }
+    // @ts-ignore
+    return _getReader(options); // Pass through other options
+  };
+
+  return stream;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,13 +2492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"peek-readable@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "peek-readable@npm:7.0.0"
-  checksum: 10c0/a979b0678a5c2b58c2a755eadc5bb990814e479ff17b9fbcec39a6c88f278eb9a788b6ae13371ee84f7a2c6672505dac961f99ccc0c0300354d9b4dc5a207604
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.0.0":
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
@@ -3151,7 +3144,6 @@ __metadata:
     del-cli: "npm:^6.0.0"
     mocha: "npm:^11.5.0"
     node-readable-to-web-readable-stream: "npm:^0.4.2"
-    peek-readable: "npm:^7.0.0"
     remark-cli: "npm:^12.0.1"
     remark-preset-lint-recommended: "npm:^7.0.1"
     token-types: "npm:^6.0.0"


### PR DESCRIPTION
As far as I can tell, [peek-readable](https://github.com/Borewit/peek-readable) is only used by [strtok3](https://github.com/Borewit/strtok3). Merging the module and repository could help simplify maintenance by reducing the number of separate packages to manage.

If you do have a module, which is solely relying on [peek-readable](https://github.com/Borewit/peek-readable), please let me know. Please describe your use case.