### PR TITLE
Reject negative ignore length

### DIFF
--- a/lib/AbstractTokenizer.ts
+++ b/lib/AbstractTokenizer.ts
@@ -110,10 +110,13 @@ export abstract class AbstractTokenizer implements ITokenizer {
 
   /**
    * Ignore number of bytes, advances the pointer in under tokenizer-stream.
-   * @param length - Number of bytes to ignore
+   * @param length - Number of bytes to ignore.  Must be ≥ 0.
    * @return resolves the number of bytes ignored, equals length if this available, otherwise the number of bytes available
    */
   public async ignore(length: number): Promise<number> {
+    if (length < 0) {
+      throw new RangeError('ignore length must be ≥ 0 bytes');
+    }
     if (this.fileInfo.size !== undefined) {
       const bytesLeft = this.fileInfo.size - this.position;
       if (length > bytesLeft) {

--- a/lib/ReadStreamTokenizer.ts
+++ b/lib/ReadStreamTokenizer.ts
@@ -86,8 +86,13 @@ export class ReadStreamTokenizer extends AbstractTokenizer {
     return bytesRead;
   }
 
+  /**
+   * @param length Number of bytes to ignore. Must be ≥ 0.
+   */
   public async ignore(length: number): Promise<number> {
-    // debug(`ignore ${this.position}...${this.position + length - 1}`);
+    if (length < 0) {
+      throw new RangeError('ignore length must be ≥ 0 bytes');
+    }
     const bufSize = Math.min(maxBufferSize, length);
     const buf = new Uint8Array(bufSize);
     let totBytesRead = 0;

--- a/test/test.ts
+++ b/test/test.ts
@@ -804,6 +804,16 @@ describe('Matrix tests', () => {
           await tokenizer.close();
         });
 
+        it('should reject negative ignore length', async () => {
+          const tokenizer = await tokenizerType.loadTokenizer('test1.dat');
+          try {
+            await expect(tokenizer.ignore(-1)).to.be.rejectedWith(RangeError, 'ignore length must be ≥ 0 bytes');
+            assert.strictEqual(tokenizer.position, 0, 'position should remain unchanged');
+          } finally {
+            await tokenizer.close();
+          }
+        });
+
         describe('End-Of-File exception behaviour', () => {
 
           it('should not throw an Error if we read exactly until the end of the file', async () => {


### PR DESCRIPTION
Adds explicit validation to reject negative values passed to `tokenizer.ignore(...)`, aligning behavior across tokenizer implementations and covering it with a regression test.

**Changes:**
- Add `RangeError` validation for `ignore(length)` when `length < 0` in `AbstractTokenizer` and `ReadStreamTokenizer`.
- Add a matrix test asserting negative ignore rejects and does not advance `position`.
- Update `ignore` parameter documentation to note the non-negative constraint.